### PR TITLE
fix: send 'uci' command before setting uci options

### DIFF
--- a/pkgs/multistockfish/CHANGELOG.md
+++ b/pkgs/multistockfish/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 0.5.0
+
+**Breaking changes:**
+
+- `Stockfish.start` now sends the "uci" command to the engine and waits for it to respond with "uciok".
+  When using the library, do *not* send "uci" yourself anymore, as that would reset UCI options.
+
+**Migration:**
+
+```dart
+// Before
+await Stockfish.instance.start(flavor: StockfishFlavor.variant, variant: 'atomic');
+// stockfish is ready, enable uci protocol.
+Stockfish.instance.stdin = 'uci';
+
+// After
+await Stockfish.instance.start(flavor: StockfishFlavor.variant, variant: 'atomic');
+// "uci" command has already been sent to `stdin` internally, stockfish is ready and in uci mode.
+```
+
 ## 0.4.0
 
 - Update latest Stockfish to version 18.

--- a/pkgs/multistockfish/lib/src/stockfish.dart
+++ b/pkgs/multistockfish/lib/src/stockfish.dart
@@ -169,6 +169,12 @@ class Stockfish {
     try {
       // Wait for the engine to be ready by checking the first non-empty line (usually its name).
       await stdout.firstWhere((line) => line.isNotEmpty).timeout(kStartTimeout);
+
+      _state._setValue(StockfishState.ready);
+
+      // Switch to the engine to UCI protocol
+      stdin = 'uci';
+      await stdout.firstWhere((line) => line == "uciok").timeout(kStartTimeout);
     } on TimeoutException {
       _state._setValue(StockfishState.error);
       _logger.severe(
@@ -176,8 +182,6 @@ class Stockfish {
       );
       rethrow;
     }
-
-    _state._setValue(StockfishState.ready);
 
     if (_flavor == StockfishFlavor.variant && _variant != null) {
       stdin = 'setoption name UCI_Variant value $_variant';


### PR DESCRIPTION
Fairy-Stockfish ignores the `setoption` command if it's sent before we have started UCI protocol by sending "uci".

One can proof this by running the following command:
```
echo "setoption name UCI_Variant value crazyhouse\nuci\nposition fen rnb1kbnr/pppqpppp/8/3P4/8/8/PPPP1PPP/RNBQKBNR[P] w KQkq - 1 3 moves P@a4\nd" | <Fairy-Stockfish-Binary>
```

Note that in the output there's no pawn on a4, even though we played the drop move P@a4. This confirms that the UCI_Variant command was not applied.

The correct way is to do it like this:
```
echo "uci\nsetoption name UCI_Variant value crazyhouse\nposition fen rnb1kbnr/pppqpppp/8/3P4/8/8/PPPP1PPP/RNBQKBNR[P] w KQkq - 1 3 moves P@a4\nd" | <Fairy-Stockfish-Binary>
```

Now it correctly prints a pawn on a4.