### PR TITLE
Fix fd leak init / crash on IOS

### DIFF
--- a/pkgs/multistockfish/lib/src/stockfish.dart
+++ b/pkgs/multistockfish/lib/src/stockfish.dart
@@ -63,6 +63,11 @@ class Stockfish {
   final _stdoutController = StreamController<String>.broadcast();
   final _mainPort = ReceivePort('Stockfish main isolate port');
   final _stdoutPort = ReceivePort('Stockfish stdout isolate port');
+  final _stdoutExitPort = ReceivePort('Stockfish stdout isolate exit port');
+
+  /// Completes when the current stdout reader isolate exits, so a restart can
+  /// wait for it before spawning a new one. `null` when no real reader runs.
+  Completer<void>? _stdoutExited;
 
   Future<void>? _pendingStart;
   Future<void>? _pendingQuit;
@@ -79,6 +84,14 @@ class Stockfish {
         _stdoutController.sink.add(message);
       } else {
         _logger.fine('The stdout isolate sent $message');
+      }
+    });
+
+    _stdoutExitPort.listen((_) {
+      _logger.fine('The stdout isolate exited');
+      final exited = _stdoutExited;
+      if (exited != null && !exited.isCompleted) {
+        exited.complete();
       }
     });
   }
@@ -152,11 +165,15 @@ class Stockfish {
   }
 
   Future<void> _doStart() async {
-    final success = await _spawnIsolates(
-      _mainPort.sendPort,
-      _stdoutPort.sendPort,
-      _flavor,
-    );
+    // Wait for the previous reader isolate to exit before reopening the pipes,
+    // otherwise two readers race on the process-global pipes and the new
+    // engine's UCI handshake is lost. Timeout avoids deadlocking on a stuck one.
+    final previousReader = _stdoutExited;
+    if (previousReader != null) {
+      await previousReader.future.timeout(kStartTimeout, onTimeout: () {});
+    }
+
+    final success = await _spawnIsolates(_flavor);
 
     if (!success) {
       _logger.severe('Failed to spawn isolates');
@@ -244,6 +261,59 @@ class Stockfish {
       exitCode == 0 ? StockfishState.initial : StockfishState.error,
     );
   }
+
+  Future<bool> _spawnIsolates(StockfishFlavor flavor) async {
+    // Check for zone override (used in tests)
+    final override = Zone.current[stockfishSpawnIsolatesKey];
+    if (override != null) {
+      // No reader isolate under the test override; nothing to join later.
+      _stdoutExited = null;
+      return (override
+          as Future<bool> Function(SendPort, SendPort, StockfishFlavor))(
+        _mainPort.sendPort,
+        _stdoutPort.sendPort,
+        flavor,
+      );
+    }
+
+    final bindings = _getBindings(flavor);
+
+    final initResult = bindings.init();
+    if (initResult != 0) {
+      _logger.severe('initResult=$initResult');
+      return false;
+    }
+
+    // Arm the completer before spawning so an early exit can't be missed.
+    final stdoutExited = Completer<void>();
+    _stdoutExited = stdoutExited;
+    try {
+      await Isolate.spawn(
+        _isolateStdout,
+        (_stdoutPort.sendPort, flavor),
+        onExit: _stdoutExitPort.sendPort,
+        debugName: 'Stockfish stdout isolate',
+      );
+    } catch (error) {
+      _logger.severe('Failed to spawn stdout isolate: $error');
+      if (!stdoutExited.isCompleted) {
+        stdoutExited.complete();
+      }
+      return false;
+    }
+
+    try {
+      await Isolate.spawn(_isolateMain, (
+        _mainPort.sendPort,
+        flavor,
+      ), debugName: 'Stockfish main isolate');
+    } catch (error) {
+      _logger.severe('Failed to spawn main isolate: $error');
+      return false;
+    }
+
+    return true;
+  }
 }
 
 DynamicLibrary _openDynamicLibrary(String libName) {
@@ -316,53 +386,6 @@ void _isolateStdout(_IsolateArgs args) {
       stdoutPort.send(line);
     }
   }
-}
-
-Future<bool> _spawnIsolates(
-  SendPort mainPort,
-  SendPort stdoutPort,
-  StockfishFlavor flavor,
-) async {
-  // Check for zone override (used in tests)
-  final override = Zone.current[stockfishSpawnIsolatesKey];
-  if (override != null) {
-    return (override
-        as Future<bool> Function(SendPort, SendPort, StockfishFlavor))(
-      mainPort,
-      stdoutPort,
-      flavor,
-    );
-  }
-
-  final bindings = _getBindings(flavor);
-
-  final initResult = bindings.init();
-  if (initResult != 0) {
-    _logger.severe('initResult=$initResult');
-    return false;
-  }
-
-  try {
-    await Isolate.spawn(_isolateStdout, (
-      stdoutPort,
-      flavor,
-    ), debugName: 'Stockfish stdout isolate');
-  } catch (error) {
-    _logger.severe('Failed to spawn stdout isolate: $error');
-    return false;
-  }
-
-  try {
-    await Isolate.spawn(_isolateMain, (
-      mainPort,
-      flavor,
-    ), debugName: 'Stockfish main isolate');
-  } catch (error) {
-    _logger.severe('Failed to spawn main isolate: $error');
-    return false;
-  }
-
-  return true;
 }
 
 typedef _IsolateArgs = (SendPort sendPort, StockfishFlavor flavor);

--- a/pkgs/multistockfish_chess/ios/Classes/stockfish_nnue.cpp
+++ b/pkgs/multistockfish_chess/ios/Classes/stockfish_nnue.cpp
@@ -45,12 +45,31 @@ namespace StockfishLatest {
 const char *QUITOK = "quitok\n";
 int pipes[NUM_PIPES][2];
 char buffer[80];
+int pipes_open = 0;
 
 int stockfish_init()
 {
-  pipe(pipes[PARENT_READ_PIPE]);
-  pipe(pipes[PARENT_WRITE_PIPE]);
+  // close the previous run's parent ends so restarts don't leak fds
+  if (pipes_open)
+  {
+    close(PARENT_READ_FD);
+    close(PARENT_WRITE_FD);
+    pipes_open = 0;
+  }
 
+  // report pipe() failures instead of returning success with bad fds
+  if (pipe(pipes[PARENT_READ_PIPE]) != 0)
+  {
+    return -1;
+  }
+  if (pipe(pipes[PARENT_WRITE_PIPE]) != 0)
+  {
+    close(pipes[PARENT_READ_PIPE][READ_FD]);
+    close(pipes[PARENT_READ_PIPE][WRITE_FD]);
+    return -1;
+  }
+
+  pipes_open = 1;
   return 0;
 }
 

--- a/pkgs/multistockfish_sf16/ios/Classes/stockfish16.cpp
+++ b/pkgs/multistockfish_sf16/ios/Classes/stockfish16.cpp
@@ -53,12 +53,31 @@ namespace Stockfish16Init {
 const char *QUITOK = "quitok\n";
 int pipes[NUM_PIPES][2];
 char buffer[80];
+int pipes_open = 0;
 
 int stockfish_init()
 {
-  pipe(pipes[PARENT_READ_PIPE]);
-  pipe(pipes[PARENT_WRITE_PIPE]);
+  // close the previous run's parent ends so restarts don't leak fds
+  if (pipes_open)
+  {
+    close(PARENT_READ_FD);
+    close(PARENT_WRITE_FD);
+    pipes_open = 0;
+  }
 
+  // report pipe() failures instead of returning success with bad fds
+  if (pipe(pipes[PARENT_READ_PIPE]) != 0)
+  {
+    return -1;
+  }
+  if (pipe(pipes[PARENT_WRITE_PIPE]) != 0)
+  {
+    close(pipes[PARENT_READ_PIPE][READ_FD]);
+    close(pipes[PARENT_READ_PIPE][WRITE_FD]);
+    return -1;
+  }
+
+  pipes_open = 1;
   return 0;
 }
 

--- a/pkgs/multistockfish_sf16/test/fd_leak/README.md
+++ b/pkgs/multistockfish_sf16/test/fd_leak/README.md
@@ -1,0 +1,47 @@
+# `stockfish_init()` file-descriptor leak test
+
+A self-contained, runnable reproducer for the fd leak fixed in
+`ios/Classes/stockfish16.cpp` (the same fix applies to the `chess` and
+`variant` flavor shims).
+
+## Run it
+
+```sh
+# Original (buggy) body -> RESULT: FAIL, exit 1
+cc -O0 -Wall fd_leak_test.c -o /tmp/fd_leak && /tmp/fd_leak; echo "exit=$?"
+
+# Shipped fix -> RESULT: PASS, exit 0
+cc -O0 -Wall -DFD_LEAK_FIXED fd_leak_test.c -o /tmp/fd_leak && /tmp/fd_leak; echo "exit=$?"
+```
+
+Or use the helper, which runs both and checks the exit codes:
+
+```sh
+./run.sh
+```
+
+## What it checks
+
+- **Experiment A** runs 40 start/quit cycles (`stockfish_init()` followed by
+  `stockfish_main()`'s child-end close) and counts open descriptors.
+  - original: `~2.00 fds/cycle` → `FAIL`
+  - fixed: `+0/cycle` (only the single live pipe pair remains) → `PASS`
+- **Experiment B** forces `EMFILE` (by holding descriptors open under a tight
+  `RLIMIT_NOFILE`) and checks `stockfish_init()`'s return value.
+  - original: returns `0` even though `pipe()` failed — the Dart layer's
+    `initResult != 0` guard is blind to the failure.
+  - fixed: returns `-1` so the failure surfaces.
+
+## Why this is a logic reproduction, not a link against the real symbol
+
+`stockfish_init()` lives in a translation unit that `#include`s the whole
+Stockfish engine (`../Stockfish16/src/*.h`), so it cannot be linked into a small
+test without building all of Stockfish. This test therefore exercises the
+**exact** pipe/`dup2`/close logic. The `FD_LEAK_FIXED` branch of
+`stockfish_init()` is copied verbatim from `stockfish16.cpp` and must stay in
+sync with it; without the macro the original two-line body is compiled.
+
+The gold-standard end-to-end check is a device/emulator test that drives the
+real `Stockfish.start()`/`quit()` and counts `/proc/self/fd` across cycles
+(Linux/Android only). That requires building the native engine and is out of
+scope for this host-only test.

--- a/pkgs/multistockfish_sf16/test/fd_leak/fd_leak_test.c
+++ b/pkgs/multistockfish_sf16/test/fd_leak/fd_leak_test.c
@@ -1,0 +1,198 @@
+// Pass/fail reproducer for the stockfish_init() fd leak. See README.md.
+//
+// The real stockfish_init() can't be linked here (its translation unit pulls in
+// all of Stockfish), so this exercises the same pipe/dup2/close logic. With
+// -DFD_LEAK_FIXED the body mirrors ios/Classes/stockfish16.cpp (must stay in
+// sync); without it, the original buggy body is compiled.
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <unistd.h>
+
+// ---- verbatim from the shim --------------------------------------------------
+#define NUM_PIPES 2
+#define PARENT_WRITE_PIPE 0
+#define PARENT_READ_PIPE 1
+#define READ_FD 0
+#define WRITE_FD 1
+#define PARENT_READ_FD (pipes[PARENT_READ_PIPE][READ_FD])
+#define PARENT_WRITE_FD (pipes[PARENT_WRITE_PIPE][WRITE_FD])
+#define CHILD_READ_FD (pipes[PARENT_WRITE_PIPE][READ_FD])
+#define CHILD_WRITE_FD (pipes[PARENT_READ_PIPE][WRITE_FD])
+
+int pipes[NUM_PIPES][2];
+int pipes_open = 0;
+
+int stockfish_init()
+{
+#ifdef FD_LEAK_FIXED
+  // --- fixed: mirrors ios/Classes/stockfish16.cpp -----------------------------
+  if (pipes_open)
+  {
+    close(PARENT_READ_FD);
+    close(PARENT_WRITE_FD);
+    pipes_open = 0;
+  }
+
+  if (pipe(pipes[PARENT_READ_PIPE]) != 0)
+  {
+    return -1;
+  }
+  if (pipe(pipes[PARENT_WRITE_PIPE]) != 0)
+  {
+    close(pipes[PARENT_READ_PIPE][READ_FD]);
+    close(pipes[PARENT_READ_PIPE][WRITE_FD]);
+    return -1;
+  }
+
+  pipes_open = 1;
+  return 0;
+#else
+  // --- original (buggy) body --------------------------------------------------
+  pipe(pipes[PARENT_READ_PIPE]);
+  pipe(pipes[PARENT_WRITE_PIPE]);
+
+  return 0;
+#endif
+}
+
+// Models stockfish_main()'s fd bookkeeping: it closes the child ends (the dup2
+// onto STDIN/STDOUT is omitted as it would corrupt fd accounting in a loop). The
+// parent ends are left open -- that is the live engine's pipe.
+void stockfish_main_close_child_ends()
+{
+  close(CHILD_READ_FD);
+  close(CHILD_WRITE_FD);
+}
+// -----------------------------------------------------------------------------
+
+static int count_open_fds(void)
+{
+  struct rlimit rl;
+  getrlimit(RLIMIT_NOFILE, &rl);
+  int max = (int)rl.rlim_cur;
+  if (max > 4096) max = 4096;
+  int n = 0;
+  for (int fd = 0; fd < max; fd++)
+  {
+    if (fcntl(fd, F_GETFD) != -1) n++;
+  }
+  return n;
+}
+
+// Experiment A: with normal limits, repeated start/quit cycles must not grow the
+// fd table. Returns 0 on PASS.
+static int experiment_a(void)
+{
+  const int cycles = 40;
+  const int base = count_open_fds();
+
+  for (int i = 0; i < cycles; i++)
+  {
+    stockfish_init();
+    stockfish_main_close_child_ends();
+  }
+
+  const int after = count_open_fds();
+  const int growth = after - base;
+
+  printf("[A] %d start/quit cycles: fd %d -> %d (growth %d, %.2f/cycle)\n",
+         cycles, base, after, growth, growth / (double)cycles);
+
+  // The fixed code keeps at most the single live pipe pair (+2) regardless of
+  // cycle count. The buggy code leaks the 2 parent ends every cycle (~+2N).
+  if (growth <= 4)
+  {
+    printf("[A] PASS: no per-cycle leak\n");
+    return 0;
+  }
+  printf("[A] FAIL: leaking ~%.0f fds/cycle across %d cycles\n",
+         growth / (double)cycles, cycles);
+  return 1;
+}
+
+// Experiment B: under an fd ceiling (forced by holding fds open), a pipe()
+// failure must reach the caller. The buggy code ignores pipe()'s return and
+// reports success, so the Dart `initResult != 0` guard is blind. Returns 0 on
+// PASS.
+static int experiment_b(void)
+{
+  // Clean slate from experiment A.
+  for (int fd = 3; fd < 4096; fd++) close(fd);
+  pipes_open = 0;
+
+  struct rlimit rl;
+  getrlimit(RLIMIT_NOFILE, &rl);
+  const struct rlimit saved = rl;
+  rl.rlim_cur = 32;
+  if (setrlimit(RLIMIT_NOFILE, &rl) != 0)
+  {
+    printf("[B] SKIP: could not lower RLIMIT_NOFILE\n");
+    return 0;
+  }
+
+  // Saturate the descriptor table, then free exactly one slot so the next
+  // pipe() (which needs two descriptors) is guaranteed to fail with EMFILE.
+  int held[64];
+  int n = 0;
+  while (n < 64)
+  {
+    int fd = dup(1);
+    if (fd < 0) break;
+    held[n++] = fd;
+  }
+  if (n >= 1)
+  {
+    close(held[n - 1]);
+    n--;
+  }
+
+  const int rc = stockfish_init();
+  const int fdValid = (fcntl(PARENT_WRITE_FD, F_GETFD) != -1);
+
+  for (int i = 0; i < n; i++) close(held[i]);
+  setrlimit(RLIMIT_NOFILE, &saved);
+
+  printf("[B] under EMFILE, stockfish_init() returned %d (pipe fds valid: %s)\n",
+         rc, fdValid ? "yes" : "no");
+
+#ifdef FD_LEAK_FIXED
+  if (rc != 0)
+  {
+    printf("[B] PASS: pipe() failure surfaces to the caller\n");
+    return 0;
+  }
+  printf("[B] FAIL: init() hid a pipe() failure\n");
+  return 1;
+#else
+  if (rc == 0 && !fdValid)
+  {
+    printf("[B] original: init() reported success (0) despite pipe() failing"
+           " -- the latent silent-failure bug\n");
+  }
+  // Informational for the buggy build; experiment A is the hard failure.
+  return 0;
+#endif
+}
+
+int main(void)
+{
+#ifdef FD_LEAK_FIXED
+  printf("== stockfish_init fd-leak test (FIXED build) ==\n");
+#else
+  printf("== stockfish_init fd-leak test (ORIGINAL build) ==\n");
+#endif
+  int failures = 0;
+  failures += experiment_a();
+  failures += experiment_b();
+
+  if (failures == 0)
+  {
+    printf("RESULT: PASS\n");
+    return 0;
+  }
+  printf("RESULT: FAIL (%d experiment(s) failed)\n", failures);
+  return 1;
+}

--- a/pkgs/multistockfish_sf16/test/fd_leak/run.sh
+++ b/pkgs/multistockfish_sf16/test/fd_leak/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Builds and runs the fd-leak reproducer both ways and asserts that the original
+# body fails and the shipped fix passes.
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+src="$here/fd_leak_test.c"
+cc=${CC:-cc}
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "### Original (buggy) — expecting FAIL"
+"$cc" -O0 -Wall "$src" -o "$tmp/orig" || exit 2
+"$tmp/orig"
+orig=$?
+echo
+
+echo "### Fixed (-DFD_LEAK_FIXED) — expecting PASS"
+"$cc" -O0 -Wall -DFD_LEAK_FIXED "$src" -o "$tmp/fixed" || exit 2
+"$tmp/fixed"
+fixed=$?
+echo
+
+if [ "$orig" -ne 0 ] && [ "$fixed" -eq 0 ]; then
+  echo "OK: original fails (exit $orig), fixed passes (exit $fixed)"
+  exit 0
+fi
+echo "UNEXPECTED: original exit=$orig (want non-zero), fixed exit=$fixed (want 0)"
+exit 1

--- a/pkgs/multistockfish_variant/ios/Classes/stockfish_variant.cpp
+++ b/pkgs/multistockfish_variant/ios/Classes/stockfish_variant.cpp
@@ -62,12 +62,31 @@ namespace MultiStockfishFairy {
 const char *QUITOK = "quitok\n";
 int pipes[NUM_PIPES][2];
 char buffer[80];
+int pipes_open = 0;
 
 int stockfish_init()
 {
-  pipe(pipes[PARENT_READ_PIPE]);
-  pipe(pipes[PARENT_WRITE_PIPE]);
+  // close the previous run's parent ends so restarts don't leak fds
+  if (pipes_open)
+  {
+    close(PARENT_READ_FD);
+    close(PARENT_WRITE_FD);
+    pipes_open = 0;
+  }
 
+  // report pipe() failures instead of returning success with bad fds
+  if (pipe(pipes[PARENT_READ_PIPE]) != 0)
+  {
+    return -1;
+  }
+  if (pipe(pipes[PARENT_WRITE_PIPE]) != 0)
+  {
+    close(pipes[PARENT_READ_PIPE][READ_FD]);
+    close(pipes[PARENT_READ_PIPE][WRITE_FD]);
+    return -1;
+  }
+
+  pipes_open = 1;
   return 0;
 }
 
@@ -75,6 +94,10 @@ int stockfish_main()
 {
   dup2(CHILD_READ_FD, STDIN_FILENO);
   dup2(CHILD_WRITE_FD, STDOUT_FILENO);
+
+  // close unused pipe fds
+  close(CHILD_READ_FD);
+  close(CHILD_WRITE_FD);
 
   int argc = 1;
   char *argv[] = {""};


### PR DESCRIPTION
Hi! Marked as draft until I can manually review all the code.

I just have huge issues with stockfish sometimes not initializing on ios and its really making the app unusable. I've been trying to fix it with Claude Opus 4.8. At the least, these appear to be real issues with the code

1. Leaking file descriptors
2. stdout reader isolate isn't joined on restart

I've tried to test it on Android Studio, but the issue doesn't seem to reproduce on Android.

Any feedback from maintainers on what looks wrong, or how I can help contribute better would be appreciated. I can't test the commit because I don't have a mac.

Issue: https://github.com/lichess-org/mobile/issues/3321
