### PR TITLE
Per-flavour dart handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ final opponent = await Stockfish.create(
 await Stockfish.create(flavor: StockfishFlavor.sf16); // throws StateError
 ```
 
-Note that a slot stays taken until `dispose()` is called, *including* after the
-engine has died on its own — the handle is the caller's to release.
+An engine that ends releases its flavor's slot without waiting to be disposed,
+so a replacement can be created straight away. `dispose()` is still what you
+call to stop one that is still running.
 
 ### UCI command
 
@@ -82,6 +83,15 @@ stockfish.stdout.listen((line) {
 });
 ```
 
+`create()` only completes once the engine is ready, so a listener attached to
+`stdout` afterwards has already missed the banner and the UCI handshake. Pass
+`onStdout` to see those too — it is attached before the engine is spawned and
+receives every line for the engine's whole life.
+
+```dart
+final stockfish = await Stockfish.create(onStdout: console.add);
+```
+
 ### Quit / Hot reload
 
 There are two active isolates per running Stockfish engine. That interferes
@@ -98,3 +108,7 @@ await stockfish.dispose();
 // the stdout stream is closed, and the handle stays dead
 print(stockfish.state.value); // StockfishState.disposed
 ```
+
+Sending `quit` over `stdin` works too: the engine exits cleanly and the handle
+ends as `disposed` just the same. Only an engine that died badly ends as
+`StockfishState.error`.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ This plugin provides the following Stockfish engines:
 
 ## Usage
 
-### Start engine
+### Start an engine
 
-`Stockfish` is a singleton. Access it via `Stockfish.instance` and call `start()` to run the engine.
+An engine is a handle you create and dispose. `Stockfish.create()` starts one
+and completes when it is ready for commands.
 
 > [!NOTE]
 > When using the `StockfishFlavor.latestNoNNUE` flavor, you need to download the `.nnue` files before
@@ -26,34 +27,44 @@ This plugin provides the following Stockfish engines:
 ```dart
 import 'package:multistockfish/multistockfish.dart';
 
-final stockfish = Stockfish.instance;
+// defaults to StockfishFlavor.sf16
+final stockfish = await Stockfish.create();
 
 // state is a ValueListenable<StockfishState>
-print(stockfish.state.value); // StockfishState.initial
-
-// start the engine (defaults to StockfishFlavor.sf16)
-await stockfish.start();
 print(stockfish.state.value); // StockfishState.ready
 
-// to change flavor, quit first then start with new configuration
-await stockfish.quit();
-await stockfish.start(
-  flavor: StockfishFlavor.variant,
-  variant: 'atomic',
-);
-
-// for latestNoNNUE flavor, NNUE file paths are required
-await stockfish.quit();
-await stockfish.start(
+// for latestNoNNUE, NNUE file paths are required
+final latest = await Stockfish.create(
   flavor: StockfishFlavor.latestNoNNUE,
   bigNetPath: '/path/to/big.nnue',
   smallNetPath: '/path/to/small.nnue',
 );
 ```
 
-### UCI command
+### One engine per flavor
 
-Wait until the state is ready before sending commands.
+**The handle is the flavor.** At most one engine per `StockfishFlavor` can be
+live at a time: `create()` throws a `StateError` while another engine of the
+same flavor holds the slot, and `dispose()` frees it. Engines of *different*
+flavors are independent and can run side by side, each with its own `stdin`,
+`stdout`, `state` and `diagnostics`.
+
+```dart
+// An NNUE engine for analysis and a Fairy-Stockfish opponent, at the same time.
+final analysis = await Stockfish.create(flavor: StockfishFlavor.sf16);
+final opponent = await Stockfish.create(
+  flavor: StockfishFlavor.variant,
+  variant: 'crazyhouse',
+);
+
+// Refused: sf16 is taken until `analysis` is disposed.
+await Stockfish.create(flavor: StockfishFlavor.sf16); // throws StateError
+```
+
+Note that a slot stays taken until `dispose()` is called, *including* after the
+engine has died on its own — the handle is the caller's to release.
+
+### UCI command
 
 ```dart
 stockfish.stdin = 'isready';
@@ -73,13 +84,17 @@ stockfish.stdout.listen((line) {
 
 ### Quit / Hot reload
 
-There are two active isolates when Stockfish engine is running. That interferes
-with Flutter's hot reload feature so you need to quit the engine before attempting to reload.
+There are two active isolates per running Stockfish engine. That interferes
+with Flutter's hot reload feature so you need to dispose your engines before
+attempting to reload.
+
+`dispose()` sends the UCI `quit` command, waits for the engine to exit and frees
+its flavor's slot. An engine that will not exit is given up on rather than
+waited for forever.
 
 ```dart
-// sends the UCI quit command
-stockfish.stdin = 'quit';
+await stockfish.dispose();
 
-// or even easier...
-await stockfish.quit();
+// the stdout stream is closed, and the handle stays dead
+print(stockfish.state.value); // StockfishState.disposed
 ```

--- a/pkgs/multistockfish/CHANGELOG.md
+++ b/pkgs/multistockfish/CHANGELOG.md
@@ -14,12 +14,18 @@ other.
   when it is ready for commands, and `dispose()`, which quits it and frees the
   flavour's slot. `create()` throws a `StateError` while another engine of the
   same flavour holds the slot.
-- A slot stays taken until `dispose()` is called, *including* after the engine
-  has died on its own: the handle is the caller's to release.
-- A handle is single use. `state` moves to `StockfishState.error` if the engine
-  dies, and to the new `StockfishState.disposed` once `dispose()` completes;
-  neither is recoverable on that handle. `stdout` closes on dispose, so it no
-  longer persists across a restart — the replacement engine has its own.
+- An engine that ends — disposed, quit over `stdin`, or crashed — releases its
+  flavour's slot without waiting to be disposed, because the native library is
+  provably free once its `main()` has returned.
+- A handle is single use. `state` ends as the new `StockfishState.disposed` —
+  after `dispose()`, or after the engine exits cleanly on its own, as it does
+  when sent `quit` over `stdin` — or as `StockfishState.error` if it died badly.
+  Neither is recoverable on that handle. `stdout` closes when the engine ends,
+  so it no longer persists across a restart — the replacement engine has its own.
+- Add an `onStdout` parameter to `create()`. `create()` only completes once the
+  engine is ready, so a listener attached to `stdout` afterwards has already
+  missed the banner and the UCI handshake; `onStdout` is attached before the
+  engine is spawned and receives every line for its whole life.
 - `dispose()` gives up on an engine that will not exit within 5 seconds instead
   of waiting for it forever, and frees the slot regardless.
 - `create()` now fails as soon as the engine exits during startup — a start the

--- a/pkgs/multistockfish/CHANGELOG.md
+++ b/pkgs/multistockfish/CHANGELOG.md
@@ -1,5 +1,53 @@
 ## 0.6.0
 
+**Breaking changes — per-flavour engine handles:**
+
+An engine is now a handle you create and dispose, rather than a process-wide
+singleton you start and quit. **The handle is the flavour**: at most one engine
+per `StockfishFlavor` can be live at a time, and engines of *different* flavours
+are independent and can run side by side — each with its own `stdin`, `stdout`,
+`state` and `diagnostics`. Running an NNUE engine for analysis while
+Fairy-Stockfish plays an opponent no longer means restarting one to get the
+other.
+
+- Add `Stockfish.create()`, which starts an engine of one flavour and completes
+  when it is ready for commands, and `dispose()`, which quits it and frees the
+  flavour's slot. `create()` throws a `StateError` while another engine of the
+  same flavour holds the slot.
+- A slot stays taken until `dispose()` is called, *including* after the engine
+  has died on its own: the handle is the caller's to release.
+- A handle is single use. `state` moves to `StockfishState.error` if the engine
+  dies, and to the new `StockfishState.disposed` once `dispose()` completes;
+  neither is recoverable on that handle. `stdout` closes on dispose, so it no
+  longer persists across a restart — the replacement engine has its own.
+- `dispose()` gives up on an engine that will not exit within 5 seconds instead
+  of waiting for it forever, and frees the slot regardless.
+- `create()` now fails as soon as the engine exits during startup — a start the
+  native library refused is reported in milliseconds with the exit code, rather
+  than as a timeout five seconds later.
+- `Stockfish.instance`, `start()` and `quit()` still work but are deprecated and
+  will be removed in the next release. The singleton competes for the same
+  per-flavour slots as `create()`, so the two APIs can be mixed during a
+  migration without ending up with two engines of one flavour.
+
+**Migration:**
+
+```dart
+// Before
+final stockfish = Stockfish.instance;
+await stockfish.start(flavor: StockfishFlavor.variant, variant: 'atomic');
+stockfish.stdin = 'go movetime 1000';
+await stockfish.quit();
+
+// After
+final stockfish = await Stockfish.create(
+  flavor: StockfishFlavor.variant,
+  variant: 'atomic',
+);
+stockfish.stdin = 'go movetime 1000';
+await stockfish.dispose();
+```
+
 - Add Swift Package Manager support for iOS.
 
 **Engine lifecycle fixes** (in the native packages, via the bumped constraints

--- a/pkgs/multistockfish/example/lib/main.dart
+++ b/pkgs/multistockfish/example/lib/main.dart
@@ -41,11 +41,20 @@ class _AppState extends State<MyApp> {
   Directory? appSupportDirectory;
   StockfishFlavor flavor = StockfishFlavor.sf16;
 
-  /// The engine currently running, if any.
+  /// The most recent engine, kept after it ends so its final state stays on
+  /// screen.
   ///
   /// Engines are per-flavor handles now: this app keeps one at a time, but
   /// nothing stops a second flavor from running alongside it.
   Stockfish? engine;
+
+  /// The console, which outlives the engines that write to it.
+  ///
+  /// An engine's own `stdout` closes when it ends, and does not exist at all
+  /// until `create` completes — by which point the banner and the UCI
+  /// handshake have already been sent. `onStdout` appends here instead, and
+  /// the log keeps every line whatever the widget tree does.
+  final _console = ConsoleLog();
 
   final Completer<NNUEFiles> _nnueFilesCompleter = Completer<NNUEFiles>();
 
@@ -112,6 +121,10 @@ class _AppState extends State<MyApp> {
   void dispose() {
     _diagnosticsTimer?.cancel();
     _diagnostics.dispose();
+    // The engine outlives this widget unless it is released here: it owns two
+    // isolates, a native engine and its flavor's slot.
+    engine?.dispose();
+    _console.dispose();
     super.dispose();
   }
 
@@ -125,6 +138,7 @@ class _AppState extends State<MyApp> {
       variant: variant,
       bigNetPath: _nnueFiles?.bigNetPath,
       smallNetPath: _nnueFiles?.smallNetPath,
+      onStdout: _console.add,
     );
     setState(() => engine = started);
   }
@@ -132,8 +146,17 @@ class _AppState extends State<MyApp> {
   Future<void> _disposeStockfish() async {
     final running = engine;
     if (running == null) return;
-    setState(() => engine = null);
+    // The handle is kept, not cleared: its state is the interesting thing to
+    // show once it has ended.
     await running.dispose();
+    if (mounted) setState(() {});
+  }
+
+  /// Sends a command, ignoring it unless the engine can accept one.
+  void _send(String command) {
+    final running = engine;
+    if (running == null || running.state.value != StockfishState.ready) return;
+    running.stdin = command;
   }
 
   Future<void> _restartStockfish() async {
@@ -291,7 +314,7 @@ class _AppState extends State<MyApp> {
                   padding: const EdgeInsets.all(8.0),
                   child: _onEngineState(
                     (state) => Text(
-                      'stockfish.state=${state ?? 'no engine'}',
+                      'stockfish.state=${state ?? 'no engine yet'}',
                       key: const ValueKey('stockfish.state'),
                     ),
                   ),
@@ -327,14 +350,18 @@ class _AppState extends State<MyApp> {
                       children: [
                         ElevatedButton(
                           onPressed:
-                              state == null || state != StockfishState.ready
-                                  ? _startStockfish
-                                  : null,
+                              state == StockfishState.ready ||
+                                      state == StockfishState.starting
+                                  ? null
+                                  : _startStockfish,
                           child: const Text('Start Stockfish'),
                         ),
                         const SizedBox(width: 8),
                         ElevatedButton(
-                          onPressed: state == null ? null : _disposeStockfish,
+                          onPressed:
+                              state == StockfishState.ready
+                                  ? _disposeStockfish
+                                  : null,
                           child: const Text('Dispose'),
                         ),
                       ],
@@ -349,7 +376,7 @@ class _AppState extends State<MyApp> {
                       labelText: 'Custom UCI command',
                       hintText: 'go infinite',
                     ),
-                    onSubmitted: (value) => engine?.stdin = value,
+                    onSubmitted: _send,
                     textInputAction: TextInputAction.send,
                   ),
                 ),
@@ -366,16 +393,14 @@ class _AppState extends State<MyApp> {
                         (command) => Padding(
                           padding: const EdgeInsets.all(8.0),
                           child: ElevatedButton(
-                            onPressed: () => engine?.stdin = command,
+                            onPressed: () => _send(command),
                             child: Text(command),
                           ),
                         ),
                       )
                       .toList(growable: false),
                 ),
-                Expanded(
-                  child: OutputWidget(engine?.stdout ?? const Stream.empty()),
-                ),
+                Expanded(child: OutputWidget(_console)),
               ],
             );
           },

--- a/pkgs/multistockfish/example/lib/main.dart
+++ b/pkgs/multistockfish/example/lib/main.dart
@@ -40,7 +40,12 @@ class MyApp extends StatefulWidget {
 class _AppState extends State<MyApp> {
   Directory? appSupportDirectory;
   StockfishFlavor flavor = StockfishFlavor.sf16;
-  final stockfish = Stockfish.instance;
+
+  /// The engine currently running, if any.
+  ///
+  /// Engines are per-flavor handles now: this app keeps one at a time, but
+  /// nothing stops a second flavor from running alongside it.
+  Stockfish? engine;
 
   final Completer<NNUEFiles> _nnueFilesCompleter = Completer<NNUEFiles>();
 
@@ -70,7 +75,10 @@ class _AppState extends State<MyApp> {
   /// signal, because a boot or a shutdown that keeps counting is a wedged
   /// engine. Sitting in the UCI loop or after exit, it is just a number going up.
   void _pollDiagnostics() {
-    final next = stockfish.diagnostics;
+    final engine = this.engine;
+    if (engine == null) return;
+
+    final next = engine.diagnostics;
     final moved = next.phase != _lastPhase || next.step != _lastStep;
 
     if (!moved && !next.phase.isTransient) return;
@@ -108,17 +116,39 @@ class _AppState extends State<MyApp> {
   }
 
   Future<void> _startStockfish() async {
-    await stockfish.start(
+    // A flavor's slot stays taken until its engine is disposed, including
+    // after the engine has died, so anything left over goes first.
+    await _disposeStockfish();
+
+    final started = await Stockfish.create(
       flavor: flavor,
       variant: variant,
       bigNetPath: _nnueFiles?.bigNetPath,
       smallNetPath: _nnueFiles?.smallNetPath,
     );
+    setState(() => engine = started);
+  }
+
+  Future<void> _disposeStockfish() async {
+    final running = engine;
+    if (running == null) return;
+    setState(() => engine = null);
+    await running.dispose();
   }
 
   Future<void> _restartStockfish() async {
-    await stockfish.quit();
+    await _disposeStockfish();
     await _startStockfish();
+  }
+
+  /// Rebuilds when the running engine changes state, or when there is none.
+  Widget _onEngineState(Widget Function(StockfishState? state) build) {
+    final running = engine;
+    if (running == null) return build(null);
+    return AnimatedBuilder(
+      animation: running.state,
+      builder: (_, _) => build(running.state.value),
+    );
   }
 
   Future<void> _fetchNNUEFiles() async {
@@ -216,7 +246,7 @@ class _AppState extends State<MyApp> {
                   child: DropdownButton<StockfishFlavor>(
                     onChanged: (value) {
                       setState(() => flavor = value!);
-                      if (stockfish.state.value == StockfishState.ready) {
+                      if (engine?.state.value == StockfishState.ready) {
                         _restartStockfish();
                       }
                     },
@@ -242,7 +272,7 @@ class _AppState extends State<MyApp> {
                     child: DropdownButton<String>(
                       onChanged: (value) {
                         setState(() => variant = value!);
-                        if (stockfish.state.value == StockfishState.ready) {
+                        if (engine?.state.value == StockfishState.ready) {
                           _restartStockfish();
                         }
                       },
@@ -259,13 +289,11 @@ class _AppState extends State<MyApp> {
                   ),
                 Padding(
                   padding: const EdgeInsets.all(8.0),
-                  child: AnimatedBuilder(
-                    animation: stockfish.state,
-                    builder:
-                        (_, __) => Text(
-                          'stockfish.state=${stockfish.state.value}',
-                          key: const ValueKey('stockfish.state'),
-                        ),
+                  child: _onEngineState(
+                    (state) => Text(
+                      'stockfish.state=${state ?? 'no engine'}',
+                      key: const ValueKey('stockfish.state'),
+                    ),
                   ),
                 ),
                 Padding(
@@ -294,18 +322,23 @@ class _AppState extends State<MyApp> {
                 ),
                 Padding(
                   padding: const EdgeInsets.all(8.0),
-                  child: AnimatedBuilder(
-                    animation: stockfish.state,
-                    builder:
-                        (_, __) => ElevatedButton(
+                  child: _onEngineState(
+                    (state) => Row(
+                      children: [
+                        ElevatedButton(
                           onPressed:
-                              stockfish.state.value == StockfishState.initial ||
-                                      stockfish.state.value ==
-                                          StockfishState.error
+                              state == null || state != StockfishState.ready
                                   ? _startStockfish
                                   : null,
                           child: const Text('Start Stockfish'),
                         ),
+                        const SizedBox(width: 8),
+                        ElevatedButton(
+                          onPressed: state == null ? null : _disposeStockfish,
+                          child: const Text('Dispose'),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
                 Padding(
@@ -316,7 +349,7 @@ class _AppState extends State<MyApp> {
                       labelText: 'Custom UCI command',
                       hintText: 'go infinite',
                     ),
-                    onSubmitted: (value) => stockfish.stdin = value,
+                    onSubmitted: (value) => engine?.stdin = value,
                     textInputAction: TextInputAction.send,
                   ),
                 ),
@@ -333,14 +366,16 @@ class _AppState extends State<MyApp> {
                         (command) => Padding(
                           padding: const EdgeInsets.all(8.0),
                           child: ElevatedButton(
-                            onPressed: () => stockfish.stdin = command,
+                            onPressed: () => engine?.stdin = command,
                             child: Text(command),
                           ),
                         ),
                       )
                       .toList(growable: false),
                 ),
-                Expanded(child: OutputWidget(stockfish.stdout)),
+                Expanded(
+                  child: OutputWidget(engine?.stdout ?? const Stream.empty()),
+                ),
               ],
             );
           },

--- a/pkgs/multistockfish/example/lib/stockfish_output.dart
+++ b/pkgs/multistockfish/example/lib/stockfish_output.dart
@@ -1,70 +1,49 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 
-class OutputWidget extends StatefulWidget {
-  final Stream<String> stdout;
+/// The engine console: an append-only log that outlives the engines writing to
+/// it.
+///
+/// Deliberately not a [Stream]. A broadcast stream drops whatever is in flight
+/// when a listener goes away, and it drops everything while there is no
+/// listener at all, so a console built on one loses lines to widget rebuilds
+/// and to the gap before the first `listen`. Appending to a list cannot.
+class ConsoleLog extends ChangeNotifier {
+  final List<String> _lines = [];
 
-  const OutputWidget(this.stdout, {super.key});
+  /// The lines received so far, newest first.
+  List<String> get lines => List.unmodifiable(_lines);
 
-  @override
-  State<StatefulWidget> createState() => _OutputState();
+  void add(String line) {
+    _lines.insert(0, line);
+    notifyListeners();
+  }
+
+  void clear() {
+    _lines.clear();
+    notifyListeners();
+  }
 }
 
-class _OutputState extends State<OutputWidget> {
-  final items = <_OutputItem>[];
+class OutputWidget extends StatelessWidget {
+  final ConsoleLog log;
 
-  late StreamSubscription subscription;
-
-  @override
-  void initState() {
-    super.initState();
-    _subscribe();
-  }
-
-  @override
-  void didUpdateWidget(OutputWidget oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.stdout != oldWidget.stdout) {
-      subscription.cancel();
-      _subscribe();
-    }
-  }
-
-  @override
-  void dispose() {
-    subscription.cancel();
-    super.dispose();
-  }
+  const OutputWidget(this.log, {super.key});
 
   @override
   Widget build(BuildContext context) {
-    return ListView.builder(itemBuilder: _buildItem, itemCount: items.length);
+    return ListenableBuilder(
+      listenable: log,
+      builder: (context, _) {
+        final lines = log.lines;
+        return ListView.builder(
+          itemCount: lines.length,
+          itemBuilder:
+              (context, index) => Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+                child: Text(lines[index]),
+              ),
+        );
+      },
+    );
   }
-
-  void _subscribe() {
-    subscription = widget.stdout.listen((line) {
-      items.insert(0, _OutputItem.line(line));
-      setState(() {});
-    });
-  }
-
-  Widget _buildItem(BuildContext context, int index) {
-    final item = items[index];
-    final line = item.line;
-    if (line != null) {
-      return Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
-        child: Text(line),
-      );
-    }
-
-    return const SizedBox.shrink();
-  }
-}
-
-class _OutputItem {
-  final String? line;
-
-  _OutputItem.line(this.line);
 }

--- a/pkgs/multistockfish/lib/src/bindings.dart
+++ b/pkgs/multistockfish/lib/src/bindings.dart
@@ -1,8 +1,30 @@
+import 'dart:convert';
 import 'dart:ffi' as ffi;
 import 'package:ffi/ffi.dart';
 import 'package:logging/logging.dart';
 
 final _logger = Logger('Stockfish');
+
+/// Decodes a NUL-terminated chunk of engine output.
+///
+/// Deliberately not `Utf8Pointer.toDartString()`, which is
+/// `utf8.decode(..., allowMalformed: false)` and therefore *throws* on a partial
+/// sequence. A chunk is a slice of a byte stream, so a multi-byte character can
+/// straddle two of them — and that throw would land in the reader isolate's loop,
+/// uncaught, killing the only thing draining the engine's pipe. The engine then
+/// blocks writing into a full pipe, stops reading commands, misses its quit, and
+/// keeps its native slot for the rest of the process's life.
+///
+/// A replacement character on one line of engine output is a far better outcome,
+/// and it makes the reader proof against malformed bytes from an engine that is
+/// already misbehaving, not only against split ones.
+String decodeEngineChunk(ffi.Pointer<ffi.Uint8> bytes) {
+  var length = 0;
+  while (bytes[length] != 0) {
+    length++;
+  }
+  return utf8.decode(bytes.asTypedList(length), allowMalformed: true);
+}
 
 /// Abstract interface for Stockfish native bindings.
 abstract class StockfishBindings {
@@ -99,7 +121,8 @@ class StockfishBindingsFFI implements StockfishBindings {
       _logger.fine('nativeStdoutRead returns NULL');
       return null;
     }
-    return pointer.toDartString();
+
+    return decodeEngineChunk(pointer.cast<ffi.Uint8>());
   }
 
   @override

--- a/pkgs/multistockfish/lib/src/stockfish.dart
+++ b/pkgs/multistockfish/lib/src/stockfish.dart
@@ -281,6 +281,14 @@ class Stockfish {
       onStdout: (line) {
         if (!_stdoutController.isClosed) _stdoutController.add(line);
       },
+      onReaderFailed: (error) {
+        _logger.severe(
+          'The reader for the ${_flavor.name} engine died, so nothing is draining its '
+          'output any more. The engine will stop answering as soon as its pipe fills, so '
+          'this session is over. $diagnostics\n$error',
+        );
+        _state._setValue(StockfishState.error);
+      },
     );
     _engine = engine;
 
@@ -678,6 +686,7 @@ class _RunningEngine {
   _RunningEngine({
     required void Function(int exitCode) onExit,
     required void Function(String line) onStdout,
+    required void Function(String error) onReaderFailed,
   }) {
     mainPort.listen((message) {
       _logger.fine('The main isolate sent $message');
@@ -692,6 +701,12 @@ class _RunningEngine {
       if (message == null) {
         _logger.fine('The stdout isolate has let go of the pipe');
         if (!readerStopped.isCompleted) readerStopped.complete();
+        return;
+      }
+
+      // The reader reporting that it died rather than finished.
+      if (message is Map) {
+        onReaderFailed('${message['error']}\n${message['stackTrace']}');
         return;
       }
 
@@ -823,6 +838,25 @@ void _isolateMain(_IsolateArgs args) {
 
 void _isolateStdout(_IsolateArgs args) {
   final (stdoutPort, flavor) = args;
+
+  try {
+    _readStdout(stdoutPort, flavor);
+  } catch (error, stackTrace) {
+    // This isolate is the only thing draining the engine's pipe. If it stops
+    // without saying so the pipe fills, the engine blocks in write() inside its
+    // UCI loop and answers nothing from then on -- a wedge with no visible
+    // cause. Reporting the failure lets the handle fail the engine instead.
+    stdoutPort.send({'error': '$error', 'stackTrace': '$stackTrace'});
+  }
+
+  // Tells the handle the pipe is free. Until this arrives the isolate is
+  // still blocked reading it, and a create() that drained the pipe in the
+  // meantime would leave it blocked forever -- a second reader stealing the
+  // next engine's output.
+  stdoutPort.send(null);
+}
+
+void _readStdout(SendPort stdoutPort, StockfishFlavor flavor) {
   final bindings = _getBindings(flavor);
 
   String previous = '';
@@ -832,11 +866,6 @@ void _isolateStdout(_IsolateArgs args) {
 
     if (stdout == null) {
       _logger.fine('nativeStdoutRead returns NULL');
-      // Tells the handle the pipe is free. Until this arrives the isolate is
-      // still blocked reading it, and a create() that drained the pipe in the
-      // meantime would leave it blocked forever -- a second reader stealing the
-      // next engine's output.
-      stdoutPort.send(null);
       return;
     }
 

--- a/pkgs/multistockfish/lib/src/stockfish.dart
+++ b/pkgs/multistockfish/lib/src/stockfish.dart
@@ -725,11 +725,11 @@ class _RunningEngine {
   /// Completes with the engine's exit code when it has actually exited.
   ///
   /// Completed only by the main isolate reporting that the engine's `main()`
-  /// returned. [detach] deliberately does not touch it: this used to double as
-  /// "the handle stopped listening", so an engine that had merely been let go of
-  /// looked exited -- and [Stockfish._quitEngine], which skips the `quit` write
-  /// for an engine that has already exited, would then silently abandon a live
-  /// engine still holding its flavor's native slot.
+  /// returned, and never by [detach]: a handle that has stopped listening says
+  /// nothing about whether the engine is still running. [Stockfish._quitEngine]
+  /// skips the `quit` write for an engine that has already exited, so anything
+  /// else completing this would abandon a live engine still holding its
+  /// flavor's native slot.
   final exited = Completer<int>();
 
   /// Completes when the reader isolate has finished with the output pipe.

--- a/pkgs/multistockfish/lib/src/stockfish.dart
+++ b/pkgs/multistockfish/lib/src/stockfish.dart
@@ -24,20 +24,38 @@ const stockfishSpawnIsolatesKey = #_stockfishSpawnIsolates;
 /// Timeout duration to consider engine start failed.
 const kStartTimeout = Duration(seconds: 5);
 
-/// How long an engine that failed to start is given to exit after being asked
-/// to quit, before it is abandoned.
+/// How long an engine is given to exit after being asked to quit, before it is
+/// abandoned.
 const kQuitTimeout = Duration(seconds: 5);
 
-/// A Dart wrapper around the Stockfish chess engine.
+/// A live Stockfish engine of one [StockfishFlavor].
 ///
-/// The engine is started in a separate isolate.
+/// Obtain one with [Stockfish.create], which starts the engine and completes
+/// once it is ready for commands, and release it with [dispose].
 ///
-/// Different flavors of Stockfish can be used by specifying the [flavor] in [start].
+/// **The handle is the flavor.** At most one engine per [StockfishFlavor] can
+/// be live at a time: [create] throws a [StateError] while another engine of
+/// the same flavor holds the slot, and [dispose] frees it. Engines of
+/// *different* flavors are independent and may be live together — an analysis
+/// engine and a variant opponent, say — each with its own [stdin], [stdout],
+/// [state] and [diagnostics].
 ///
-/// This is a singleton - use [Stockfish.instance] to access it.
+/// A handle is single-use. Once [dispose] has been called, or the engine has
+/// exited on its own, that handle stays dead; call [create] again for a fresh
+/// one.
 class Stockfish {
-  /// The singleton instance of Stockfish.
-  static final Stockfish instance = Stockfish._();
+  Stockfish._(this._flavor, {bool legacy = false}) : _legacy = legacy;
+
+  /// The engines currently holding their flavor's slot.
+  static final Map<StockfishFlavor, Stockfish> _live = {};
+
+  /// The engines currently live, by flavor.
+  ///
+  /// The slots are process-wide, so a test that leaves one claimed leaks it
+  /// into the next test.
+  @visibleForTesting
+  static Map<StockfishFlavor, Stockfish> get debugLiveEngines =>
+      Map.unmodifiable(_live);
 
   /// The default big NNUE file for evaluation of [StockfishFlavor.latestNoNNUE].
   static const latestBigNNUE = 'nn-c288c895ea92.nnue';
@@ -45,12 +63,66 @@ class Stockfish {
   /// The default small NNUE file for evaluation of [StockfishFlavor.latestNoNNUE].
   static const latestSmallNNUE = 'nn-37f18f62d772.nnue';
 
-  StockfishFlavor _flavor = StockfishFlavor.sf16;
+  /// Starts an engine of [flavor] and completes when it is ready for commands.
+  ///
+  /// When [flavor] is [StockfishFlavor.latestNoNNUE], [smallNetPath] and
+  /// [bigNetPath] must be provided.
+  ///
+  /// Throws a [StateError] if an engine of [flavor] is already live — call
+  /// [dispose] on it first — and a [TimeoutException] if the engine does not
+  /// become ready within [kStartTimeout]. A failed create frees the slot again,
+  /// but an engine that also refused to quit keeps its native state, and the
+  /// next create for that flavor may be refused by the native library until the
+  /// process restarts.
+  static Future<Stockfish> create({
+    /// The flavor of Stockfish to use.
+    StockfishFlavor flavor = StockfishFlavor.sf16,
+
+    /// The variant of chess to use. (Only for [StockfishFlavor.variant]).
+    ///
+    /// Example: '3check', 'crazyhouse', 'atomic', 'kingofthehill', 'antichess', 'horde', 'racingkings'.
+    String? variant,
+
+    /// Full path to the small net file for NNUE evaluation. Only used for [StockfishFlavor.latestNoNNUE].
+    String? smallNetPath,
+
+    /// Full path to the big net file for NNUE evaluation. Only used for [StockfishFlavor.latestNoNNUE].
+    String? bigNetPath,
+  }) async {
+    assert(
+      flavor != StockfishFlavor.latestNoNNUE ||
+          (smallNetPath != null && bigNetPath != null),
+      'NNUE evaluation requires smallNetPath and bigNetPath',
+    );
+
+    // Claiming the slot before the first await is what makes two concurrent
+    // create() calls for one flavor resolve to a refusal rather than to two
+    // engines racing each other into the same native globals.
+    final engine =
+        Stockfish._(flavor)
+          .._variant = variant
+          .._smallNetPath = smallNetPath
+          .._bigNetPath = bigNetPath;
+    engine._claimSlot(flavor);
+
+    try {
+      await engine._doStart();
+    } catch (_) {
+      engine._release(StockfishState.error, closeStdout: true);
+      rethrow;
+    }
+
+    return engine;
+  }
+
+  final bool _legacy;
+
+  StockfishFlavor _flavor;
   String? _variant;
   String? _smallNetPath;
   String? _bigNetPath;
 
-  /// The flavor of Stockfish currently configured.
+  /// The flavor of Stockfish this engine runs.
   StockfishFlavor get flavor => _flavor;
 
   /// The variant of chess. (Only for [StockfishFlavor.variant]).
@@ -72,13 +144,23 @@ class Stockfish {
 
   Future<void>? _pendingStart;
   Future<void>? _pendingQuit;
+  Future<void>? _pendingDispose;
 
-  Stockfish._();
+  /// Whether [dispose] has been called, recorded before anything it does can
+  /// make the engine exit, so that [_onEngineExit] knows the exit was asked for.
+  bool _disposing = false;
 
   /// The current state of the underlying C++ engine.
+  ///
+  /// A handle returned by [create] is [StockfishState.ready]. It moves to
+  /// [StockfishState.error] if the engine dies on its own, and to
+  /// [StockfishState.disposed] once [dispose] completes; neither is recoverable
+  /// on this handle.
   ValueListenable<StockfishState> get state => _state;
 
   /// The standard output stream.
+  ///
+  /// Closes when the engine is disposed.
   Stream<String> get stdout => _stdoutController.stream;
 
   /// A snapshot of what the native engine is doing.
@@ -121,7 +203,7 @@ class Stockfish {
   ///
   /// Negative values are failures described by [describeWriteCode]. They are
   /// logged here so that every caller reports them the same way, and returned
-  /// so that callers who cannot simply carry on — [quit] in particular — can
+  /// so that callers who cannot simply carry on — [dispose] in particular — can
   /// act on them.
   int _write(String line) {
     _logger.finest('[stdin] $line');
@@ -137,17 +219,244 @@ class Stockfish {
         // The engine can no longer be sent a coherent command stream, so this
         // session is over whatever the engine itself does next. Failing the
         // state here makes the rest of the API refuse work until the caller
-        // restarts, instead of letting commands accumulate on a broken channel
-        // and be answered with nonsense.
+        // starts another engine, instead of letting commands accumulate on a
+        // broken channel and be answered with nonsense.
         _logger.severe(
           'The engine session is unrecoverable and has been marked failed. '
-          'Call start() again to obtain a working engine.',
+          'Dispose this engine and create another one.',
         );
         _state._setValue(StockfishState.error);
       }
     }
     return written;
   }
+
+  /// Takes [flavor]'s slot, or throws if another engine still holds it.
+  void _claimSlot(StockfishFlavor flavor) {
+    if (_live.containsKey(flavor)) {
+      throw StateError(
+        'A ${flavor.name} engine is already live. Dispose it before creating '
+        'another one of the same flavor. (Engines of other flavors are '
+        'unaffected and can run alongside it.)',
+      );
+    }
+    _flavor = flavor;
+    _live[flavor] = this;
+  }
+
+  /// Gives this flavor's slot back, if this engine still holds it.
+  void _releaseSlot() {
+    if (identical(_live[_flavor], this)) _live.remove(_flavor);
+  }
+
+  Future<void> _doStart() async {
+    late final _RunningEngine engine;
+    engine = _RunningEngine(
+      onExit: (exitCode) {
+        if (identical(_engine, engine)) _engine = null;
+        _onEngineExit(exitCode);
+      },
+      onStdout: (line) {
+        if (!_stdoutController.isClosed) _stdoutController.add(line);
+      },
+    );
+    _engine = engine;
+
+    final success = await _spawnIsolates(
+      engine.mainPort.sendPort,
+      engine.stdoutPort.sendPort,
+      _flavor,
+    );
+
+    if (!success) {
+      _logger.severe('Failed to spawn isolates');
+      _engine = null;
+      engine.dispose();
+      throw Exception('Failed to spawn isolates');
+    }
+
+    _state._setValue(StockfishState.starting);
+
+    try {
+      // Wait for the engine to be ready by checking the first non-empty line (usually its name).
+      await _awaitLine(engine, (line) => line.isNotEmpty);
+
+      _state._setValue(StockfishState.ready);
+
+      // Switch to the engine to UCI protocol
+      stdin = 'uci';
+      await _awaitLine(engine, (line) => line == 'uciok');
+    } on TimeoutException {
+      // Read the diagnostics before asking the engine to quit: doing so moves
+      // it on to another phase and would erase the evidence of where it stalled.
+      final stalledAt = diagnostics;
+      _logger.severe(
+        'The engine (${_flavor.name}) did not become ready in time '
+        '(${kStartTimeout.inSeconds}s). $stalledAt',
+      );
+      await _quitEngine(engine);
+      throw TimeoutException(
+        'Stockfish (${_flavor.name}) did not become ready in time. $stalledAt',
+        kStartTimeout,
+      );
+    }
+
+    if (_flavor == StockfishFlavor.variant && _variant != null) {
+      stdin = 'setoption name UCI_Variant value $_variant';
+    }
+
+    if (_flavor == StockfishFlavor.latestNoNNUE &&
+        _bigNetPath != null &&
+        _smallNetPath != null) {
+      stdin = 'setoption name EvalFile value $_bigNetPath';
+      stdin = 'setoption name EvalFileSmall value $_smallNetPath';
+    }
+  }
+
+  /// Waits for [engine] to print a line matching [test].
+  ///
+  /// Throws a [TimeoutException] after [kStartTimeout], and gives up as soon as
+  /// the engine exits instead: an engine the native library refused to run
+  /// reports that in milliseconds, and waiting out the timeout would replace a
+  /// precise answer with a vague one.
+  Future<void> _awaitLine(
+    _RunningEngine engine,
+    bool Function(String line) test,
+  ) {
+    final completer = Completer<void>();
+
+    final subscription = _stdoutController.stream.listen((line) {
+      if (!completer.isCompleted && test(line)) completer.complete();
+    });
+
+    unawaited(
+      engine.exited.future.then((exitCode) {
+        if (completer.isCompleted) return;
+        completer.completeError(
+          Exception(
+            'The ${_flavor.name} engine exited while starting '
+            '${exitCode == null ? '' : '(code $exitCode: '
+                    '${describeMainExitCode(exitCode)}) '}'
+            'and will never become ready. $diagnostics',
+          ),
+        );
+      }),
+    );
+
+    return completer.future
+        .timeout(kStartTimeout)
+        .whenComplete(subscription.cancel);
+  }
+
+  /// Quits the engine and frees its flavor's slot.
+  ///
+  /// Completes when the engine has exited. It is safe to call more than once
+  /// and safe to call on an engine that has already died; later calls wait for
+  /// the first.
+  ///
+  /// An engine that does not exit within [kQuitTimeout] is abandoned: the slot
+  /// is freed and everything the engine sends afterwards is dropped, but it
+  /// keeps the native state it is stuck in, so a later [create] for this flavor
+  /// may be refused until the process restarts.
+  Future<void> dispose() {
+    if (_legacy) {
+      // Disposing the singleton would close the stdout stream every caller
+      // shares and leave no way back, so this is refused rather than honoured.
+      throw StateError(
+        'Stockfish.instance cannot be disposed: it is a process-wide singleton '
+        'and callers share its streams. Use quit(), or migrate to an engine of '
+        'your own from Stockfish.create().',
+      );
+    }
+    _disposing = true;
+    return _pendingDispose ??= _doDispose();
+  }
+
+  Future<void> _doDispose() async {
+    final engine = _engine;
+    if (engine != null) await _quitEngine(engine);
+    _release(StockfishState.disposed, closeStdout: true);
+  }
+
+  /// Asks [engine] to quit and waits for it to exit.
+  ///
+  /// Waiting matters even where the caller has stopped caring: another engine
+  /// of this flavor may be created as soon as this returns, and one still
+  /// winding down would otherwise report its exit while its successor runs.
+  Future<void> _quitEngine(_RunningEngine engine) async {
+    if (!engine.exited.isCompleted) {
+      if (_write('quit') < 0) {
+        _logger.severe(
+          'The engine could not be asked to quit and will never report an '
+          'exit. Giving up on a clean shutdown. $diagnostics',
+        );
+      } else {
+        try {
+          await engine.exited.future.timeout(kQuitTimeout);
+        } on TimeoutException {
+          _logger.severe(
+            'The ${_flavor.name} engine did not exit in time '
+            '(${kQuitTimeout.inSeconds}s). $diagnostics '
+            'It is abandoned: nothing it sends from now on is delivered, but '
+            'until this process is restarted a new ${_flavor.name} engine may '
+            'be refused by the native library, because the engine keeps its '
+            'state in process globals the stuck one still owns.',
+          );
+        }
+      }
+    }
+
+    if (identical(_engine, engine)) _engine = null;
+    engine.dispose();
+  }
+
+  /// Ends this engine's session: slot returned, ports closed, state published.
+  void _release(StockfishState finalState, {required bool closeStdout}) {
+    _releaseSlot();
+    _engine?.dispose();
+    _engine = null;
+    _state._setValue(finalState);
+    if (closeStdout && !_stdoutController.isClosed) _stdoutController.close();
+  }
+
+  void _onEngineExit(int exitCode) {
+    if (exitCode == 0) {
+      _logger.fine('The engine exited cleanly.');
+    } else {
+      _logger.severe(
+        'The engine exited with code $exitCode: '
+        '${describeMainExitCode(exitCode)}. $diagnostics',
+      );
+    }
+
+    if (_legacy) {
+      _releaseSlot();
+      _state._setValue(
+        exitCode == 0 ? StockfishState.initial : StockfishState.error,
+      );
+      return;
+    }
+
+    // A handle whose engine is gone is unusable whatever the exit code, so an
+    // exit nobody asked for is an error. When dispose() asked for it, it
+    // publishes the final state itself.
+    if (!_disposing) _state._setValue(StockfishState.error);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Deprecated singleton facade.
+  // ---------------------------------------------------------------------------
+
+  /// The singleton instance of Stockfish.
+  @Deprecated(
+    'Use Stockfish.create() and dispose() instead: engines are now per-flavor '
+    'handles, so several flavors can be live at once and each has its own '
+    'state and streams. This singleton will be removed in the next release.',
+  )
+  static final Stockfish instance = Stockfish._(
+    StockfishFlavor.sf16,
+    legacy: true,
+  );
 
   /// Starts the C++ engine.
   ///
@@ -156,6 +465,10 @@ class Stockfish {
   /// When [flavor] is [StockfishFlavor.latestNoNNUE], [smallNetPath] and [bigNetPath] must be provided.
   ///
   /// Throws a [TimeoutException] if the engine does not become ready in time.
+  @Deprecated(
+    'Use Stockfish.create() instead, which returns an engine of its own '
+    'rather than reconfiguring a shared one.',
+  )
   Future<void> start({
     /// The flavor of Stockfish to use.
     StockfishFlavor flavor = StockfishFlavor.sf16,
@@ -171,6 +484,11 @@ class Stockfish {
     /// Full path to the big net file for NNUE evaluation. Only used for [StockfishFlavor.latestNoNNUE].
     String? bigNetPath,
   }) {
+    assert(
+      _legacy,
+      'start() only exists on the deprecated Stockfish.instance. An engine '
+      'from Stockfish.create() is already started.',
+    );
     assert(
       flavor != StockfishFlavor.latestNoNNUE ||
           (smallNetPath != null && bigNetPath != null),
@@ -191,75 +509,28 @@ class Stockfish {
       );
     }
 
-    _flavor = flavor;
+    // The singleton competes for the same per-flavor slots as create(), so a
+    // caller half-migrated to handles cannot end up with two engines of one
+    // flavor by using both APIs.
+    _claimSlot(flavor);
+
     _variant = variant;
     _smallNetPath = smallNetPath;
     _bigNetPath = bigNetPath;
 
-    return _pendingStart = _doStart().whenComplete(() => _pendingStart = null);
+    return _pendingStart = _legacyStart().whenComplete(
+      () => _pendingStart = null,
+    );
   }
 
-  Future<void> _doStart() async {
-    late final _RunningEngine engine;
-    engine = _RunningEngine(
-      onExit: (exitCode) {
-        if (identical(_engine, engine)) _engine = null;
-        _onEngineExit(exitCode);
-      },
-      onStdout: _stdoutController.sink.add,
-    );
-    _engine = engine;
-
-    final success = await _spawnIsolates(
-      engine.mainPort.sendPort,
-      engine.stdoutPort.sendPort,
-      _flavor,
-    );
-
-    if (!success) {
-      _logger.severe('Failed to spawn isolates');
-      _engine = null;
-      engine.dispose();
-      _state._setValue(StockfishState.error);
-      throw Exception('Failed to spawn isolates');
-    }
-
-    _state._setValue(StockfishState.starting);
-
+  Future<void> _legacyStart() async {
     try {
-      // Wait for the engine to be ready by checking the first non-empty line (usually its name).
-      await stdout.firstWhere((line) => line.isNotEmpty).timeout(kStartTimeout);
-
-      _state._setValue(StockfishState.ready);
-
-      // Switch to the engine to UCI protocol
-      stdin = 'uci';
-      await stdout.firstWhere((line) => line == "uciok").timeout(kStartTimeout);
-    } on TimeoutException {
-      // Read the diagnostics before asking the engine to quit: doing so moves
-      // it on to another phase and would erase the evidence of where it stalled.
-      final stalledAt = diagnostics;
-      _logger.severe(
-        'The engine (${_flavor.name}) did not become ready in time '
-        '(${kStartTimeout.inSeconds}s). $stalledAt',
-      );
-      await _abandonEngine(engine);
-      _state._setValue(StockfishState.error);
-      throw TimeoutException(
-        'Stockfish (${_flavor.name}) did not become ready in time. $stalledAt',
-        kStartTimeout,
-      );
-    }
-
-    if (_flavor == StockfishFlavor.variant && _variant != null) {
-      stdin = 'setoption name UCI_Variant value $_variant';
-    }
-
-    if (_flavor == StockfishFlavor.latestNoNNUE &&
-        _bigNetPath != null &&
-        _smallNetPath != null) {
-      stdin = 'setoption name EvalFile value $_bigNetPath';
-      stdin = 'setoption name EvalFileSmall value $_smallNetPath';
+      await _doStart();
+    } catch (_) {
+      // The singleton survives a failed start and can be started again, so it
+      // keeps its stdout stream; only the slot and the state are reset.
+      _release(StockfishState.error, closeStdout: false);
+      rethrow;
     }
   }
 
@@ -270,7 +541,17 @@ class Stockfish {
   /// After quitting, the engine can be started again with [start].
   ///
   /// It is safe to call [quit] multiple times; subsequent calls will wait for the first to complete.
+  @Deprecated(
+    'Use dispose() on an engine from Stockfish.create() instead. Unlike quit(), '
+    'it also gives up on an engine that will not exit.',
+  )
   Future<void> quit() {
+    assert(
+      _legacy,
+      'quit() only exists on the deprecated Stockfish.instance. Use dispose() '
+      'on an engine from Stockfish.create().',
+    );
+
     if (_pendingQuit != null) {
       return _pendingQuit!;
     }
@@ -278,6 +559,7 @@ class Stockfish {
     switch (_state.value) {
       case StockfishState.initial:
       case StockfishState.error:
+      case StockfishState.disposed:
         return Future.value();
       case StockfishState.starting:
       case StockfishState.ready:
@@ -318,56 +600,16 @@ class Stockfish {
         'The engine could not be asked to quit and will never report an exit. '
         'Giving up on a clean shutdown. $diagnostics',
       );
+      _releaseSlot();
       _state._setValue(StockfishState.error);
     }
-  }
-
-  /// Asks an engine that failed to start to quit, and waits for it to exit.
-  ///
-  /// Waiting matters: [start] may be called again as soon as it throws, and an
-  /// engine still winding down would otherwise report its exit while its
-  /// successor is running, resetting the state of a perfectly healthy engine.
-  ///
-  /// An engine that does not exit within [kQuitTimeout] is given up on, but it
-  /// is disposed all the same so that whatever it sends afterwards is dropped.
-  Future<void> _abandonEngine(_RunningEngine engine) async {
-    _write('quit');
-    try {
-      await engine.exited.future.timeout(kQuitTimeout);
-    } on TimeoutException {
-      _logger.severe(
-        'The engine did not exit in time (${kQuitTimeout.inSeconds}s) after a '
-        'failed start. $diagnostics '
-        'Until this process is restarted, further start() calls will be refused '
-        'by the native library, because the engine keeps its state in process '
-        'globals that the stuck engine still owns.',
-      );
-    } finally {
-      if (identical(_engine, engine)) _engine = null;
-      engine.dispose();
-    }
-  }
-
-  void _onEngineExit(int exitCode) {
-    if (exitCode == 0) {
-      _logger.fine('The engine exited cleanly.');
-    } else {
-      _logger.severe(
-        'The engine exited with code $exitCode: '
-        '${describeMainExitCode(exitCode)}. $diagnostics',
-      );
-    }
-
-    _state._setValue(
-      exitCode == 0 ? StockfishState.initial : StockfishState.error,
-    );
   }
 }
 
 /// The ports of a single engine, and its lifetime.
 ///
 /// Each engine gets its own ports so that closing them is enough to make an
-/// abandoned engine invisible to the [Stockfish] singleton.
+/// abandoned engine invisible to the [Stockfish] handle that started it.
 class _RunningEngine {
   _RunningEngine({
     required void Function(int exitCode) onExit,
@@ -375,8 +617,9 @@ class _RunningEngine {
   }) {
     mainPort.listen((message) {
       _logger.fine('The main isolate sent $message');
+      _exitCode = message is int ? message : 1;
       dispose();
-      onExit(message is int ? message : 1);
+      onExit(_exitCode!);
     });
 
     stdoutPort.listen((message) {
@@ -392,9 +635,11 @@ class _RunningEngine {
   final mainPort = ReceivePort('Stockfish main isolate port');
   final stdoutPort = ReceivePort('Stockfish stdout isolate port');
 
-  /// Completes when the engine has exited, or when it is disposed.
-  final exited = Completer<void>();
+  /// Completes when the engine has exited, with its exit code, or with null
+  /// when it was disposed without reporting one.
+  final exited = Completer<int?>();
 
+  int? _exitCode;
   bool _disposed = false;
 
   /// Stops listening to this engine's isolates.
@@ -403,7 +648,7 @@ class _RunningEngine {
     _disposed = true;
     mainPort.close();
     stdoutPort.close();
-    if (!exited.isCompleted) exited.complete();
+    if (!exited.isCompleted) exited.complete(_exitCode);
   }
 }
 

--- a/pkgs/multistockfish/lib/src/stockfish.dart
+++ b/pkgs/multistockfish/lib/src/stockfish.dart
@@ -28,6 +28,12 @@ const kStartTimeout = Duration(seconds: 5);
 /// abandoned.
 const kQuitTimeout = Duration(seconds: 5);
 
+/// How long an exited engine's reader is given to let go of the pipe.
+///
+/// Short, because the marker it is waiting for is already in the pipe by then:
+/// this is a thread wake-up, not work.
+const kReaderStopTimeout = Duration(seconds: 1);
+
 /// A live Stockfish engine of one [StockfishFlavor].
 ///
 /// Obtain one with [Stockfish.create], which starts the engine and completes
@@ -267,6 +273,10 @@ class Stockfish {
       onExit: (exitCode) {
         if (identical(_engine, engine)) _engine = null;
         _onEngineExit(exitCode);
+        // When dispose() asked for the exit it detaches itself, once it has
+        // waited for the reader to let go of the pipe. Every other way an engine
+        // can end has nobody waiting, so the ports are closed here instead.
+        if (!_disposing) engine.detach();
       },
       onStdout: (line) {
         if (!_stdoutController.isClosed) _stdoutController.add(line);
@@ -283,7 +293,7 @@ class Stockfish {
     if (!success) {
       _logger.severe('Failed to spawn isolates');
       _engine = null;
-      engine.dispose();
+      engine.detach();
       throw Exception('Failed to spawn isolates');
     }
 
@@ -347,8 +357,7 @@ class Stockfish {
         completer.completeError(
           Exception(
             'The ${_flavor.name} engine exited while starting '
-            '${exitCode == null ? '' : '(code $exitCode: '
-                    '${describeMainExitCode(exitCode)}) '}'
+            '(code $exitCode: ${describeMainExitCode(exitCode)}) '
             'and will never become ready. $diagnostics',
           ),
         );
@@ -370,6 +379,10 @@ class Stockfish {
   /// is freed and everything the engine sends afterwards is dropped, but it
   /// keeps the native state it is stuck in, so a later [create] for this flavor
   /// may be refused until the process restarts.
+  ///
+  /// An engine that does exit is also waited on for [kReaderStopTimeout], so
+  /// that its reader has let go of the output pipe before the next engine of
+  /// this flavor can drain it.
   Future<void> dispose() {
     if (_legacy) {
       // Disposing the singleton would close the stdout stream every caller
@@ -426,14 +439,35 @@ class Stockfish {
       }
     }
 
+    // The engine has gone, but its reader has not necessarily noticed: it learns
+    // that from the quit marker in the pipe, and until it has read it the isolate
+    // is still blocked on that pipe. The next create() drains the pipe before it
+    // starts its engine, and a drain that beats the reader to the marker leaves
+    // it blocked forever -- a second reader on the new engine's output, taking
+    // lines at random from the isolate that is supposed to deliver them.
+    //
+    // Only worth waiting for when the engine actually exited: an abandoned one
+    // never writes the marker, and its reader is never going to stop.
+    if (engine.exited.isCompleted) {
+      try {
+        await engine.readerStopped.future.timeout(kReaderStopTimeout);
+      } on TimeoutException {
+        _logger.warning(
+          'The ${_flavor.name} engine exited but its reader did not let go of '
+          'the pipe within ${kReaderStopTimeout.inMilliseconds}ms. A new engine '
+          'of this flavor may lose output to it. $diagnostics',
+        );
+      }
+    }
+
     if (identical(_engine, engine)) _engine = null;
-    engine.dispose();
+    engine.detach();
   }
 
   /// Ends this engine's session: slot returned, ports closed, state published.
   void _release(StockfishState finalState, {required bool closeStdout}) {
     _releaseSlot();
-    _engine?.dispose();
+    _engine?.detach();
     _engine = null;
     _state._setValue(finalState);
     if (closeStdout && !_stdoutController.isClosed) _stdoutController.close();
@@ -647,12 +681,20 @@ class _RunningEngine {
   }) {
     mainPort.listen((message) {
       _logger.fine('The main isolate sent $message');
-      _exitCode = message is int ? message : 1;
-      dispose();
-      onExit(_exitCode!);
+      final code = message is int ? message : 1;
+      // The only thing that completes [exited]; see its doc comment.
+      if (!exited.isCompleted) exited.complete(code);
+      onExit(code);
     });
 
     stdoutPort.listen((message) {
+      // The reader's own end of stream, not engine output.
+      if (message == null) {
+        _logger.fine('The stdout isolate has let go of the pipe');
+        if (!readerStopped.isCompleted) readerStopped.complete();
+        return;
+      }
+
       // A batch of lines from the reader, or a single line from a test's fake.
       final lines = switch (message) {
         final List<Object?> batch => batch,
@@ -680,20 +722,33 @@ class _RunningEngine {
   final mainPort = ReceivePort('Stockfish main isolate port');
   final stdoutPort = ReceivePort('Stockfish stdout isolate port');
 
-  /// Completes when the engine has exited, with its exit code, or with null
-  /// when it was disposed without reporting one.
-  final exited = Completer<int?>();
+  /// Completes with the engine's exit code when it has actually exited.
+  ///
+  /// Completed only by the main isolate reporting that the engine's `main()`
+  /// returned. [detach] deliberately does not touch it: this used to double as
+  /// "the handle stopped listening", so an engine that had merely been let go of
+  /// looked exited -- and [Stockfish._quitEngine], which skips the `quit` write
+  /// for an engine that has already exited, would then silently abandon a live
+  /// engine still holding its flavor's native slot.
+  final exited = Completer<int>();
 
-  int? _exitCode;
-  bool _disposed = false;
+  /// Completes when the reader isolate has finished with the output pipe.
+  ///
+  /// Not the same event as the engine exiting: the reader learns of that from
+  /// the quit marker in the pipe, which it may not have read yet.
+  final readerStopped = Completer<void>();
+
+  bool _detached = false;
 
   /// Stops listening to this engine's isolates.
-  void dispose() {
-    if (_disposed) return;
-    _disposed = true;
+  ///
+  /// Says nothing about the engine, which may still be running: this is the
+  /// handle letting go, not the engine ending.
+  void detach() {
+    if (_detached) return;
+    _detached = true;
     mainPort.close();
     stdoutPort.close();
-    if (!exited.isCompleted) exited.complete(_exitCode);
   }
 }
 
@@ -777,6 +832,11 @@ void _isolateStdout(_IsolateArgs args) {
 
     if (stdout == null) {
       _logger.fine('nativeStdoutRead returns NULL');
+      // Tells the handle the pipe is free. Until this arrives the isolate is
+      // still blocked reading it, and a create() that drained the pipe in the
+      // meantime would leave it blocked forever -- a second reader stealing the
+      // next engine's output.
+      stdoutPort.send(null);
       return;
     }
 

--- a/pkgs/multistockfish/lib/src/stockfish.dart
+++ b/pkgs/multistockfish/lib/src/stockfish.dart
@@ -42,7 +42,8 @@ const kQuitTimeout = Duration(seconds: 5);
 ///
 /// A handle is single-use. Once [dispose] has been called, or the engine has
 /// exited on its own, that handle stays dead; call [create] again for a fresh
-/// one.
+/// one. An engine that exits releases its flavor's slot without waiting to be
+/// disposed, so a replacement can be created straight away.
 class Stockfish {
   Stockfish._(this._flavor, {bool legacy = false}) : _legacy = legacy;
 
@@ -74,6 +75,12 @@ class Stockfish {
   /// but an engine that also refused to quit keeps its native state, and the
   /// next create for that flavor may be refused by the native library until the
   /// process restarts.
+  ///
+  /// Pass [onStdout] to see the engine's startup output. This future does not
+  /// complete until the engine is ready, so a listener attached to [stdout]
+  /// afterwards has already missed the banner and the UCI handshake;
+  /// [onStdout] is attached before the engine is spawned and receives every
+  /// line for its whole life.
   static Future<Stockfish> create({
     /// The flavor of Stockfish to use.
     StockfishFlavor flavor = StockfishFlavor.sf16,
@@ -88,6 +95,9 @@ class Stockfish {
 
     /// Full path to the big net file for NNUE evaluation. Only used for [StockfishFlavor.latestNoNNUE].
     String? bigNetPath,
+
+    /// Receives every line the engine writes, starting from its first.
+    void Function(String line)? onStdout,
   }) async {
     assert(
       flavor != StockfishFlavor.latestNoNNUE ||
@@ -104,6 +114,7 @@ class Stockfish {
           .._smallNetPath = smallNetPath
           .._bigNetPath = bigNetPath;
     engine._claimSlot(flavor);
+    if (onStdout != null) engine._stdoutController.stream.listen(onStdout);
 
     try {
       await engine._doStart();
@@ -152,10 +163,11 @@ class Stockfish {
 
   /// The current state of the underlying C++ engine.
   ///
-  /// A handle returned by [create] is [StockfishState.ready]. It moves to
-  /// [StockfishState.error] if the engine dies on its own, and to
-  /// [StockfishState.disposed] once [dispose] completes; neither is recoverable
-  /// on this handle.
+  /// A handle returned by [create] is [StockfishState.ready]. It ends as
+  /// [StockfishState.disposed] — after [dispose], or after the engine exits
+  /// cleanly on its own, as it does when sent `quit` over [stdin] — or as
+  /// [StockfishState.error] if it died badly. None of those is recoverable on
+  /// this handle: create another one.
   ValueListenable<StockfishState> get state => _state;
 
   /// The standard output stream.
@@ -375,7 +387,15 @@ class Stockfish {
   Future<void> _doDispose() async {
     final engine = _engine;
     if (engine != null) await _quitEngine(engine);
-    _release(StockfishState.disposed, closeStdout: true);
+
+    // A handle that already failed goes on saying so. Disposing it is not what
+    // went wrong, and of the two facts the failure is the one worth keeping.
+    _release(
+      _state.value == StockfishState.error
+          ? StockfishState.error
+          : StockfishState.disposed,
+      closeStdout: true,
+    );
   }
 
   /// Asks [engine] to quit and waits for it to exit.
@@ -437,10 +457,20 @@ class Stockfish {
       return;
     }
 
-    // A handle whose engine is gone is unusable whatever the exit code, so an
-    // exit nobody asked for is an error. When dispose() asked for it, it
-    // publishes the final state itself.
-    if (!_disposing) _state._setValue(StockfishState.error);
+    // When dispose() asked for the exit, it publishes the final state itself.
+    if (_disposing) return;
+
+    // The handle is finished either way, but only a bad exit is a failure: an
+    // engine told `quit` over [stdin] exits cleanly and nothing went wrong.
+    //
+    // The flavor is free whatever the code, because the engine is provably
+    // gone — that is exactly what the native library's re-entry guard keys off.
+    // Holding the slot until dispose() would only make the caller ask
+    // permission to replace an engine that no longer exists.
+    _release(
+      exitCode == 0 ? StockfishState.disposed : StockfishState.error,
+      closeStdout: true,
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/pkgs/multistockfish/lib/src/stockfish.dart
+++ b/pkgs/multistockfish/lib/src/stockfish.dart
@@ -653,11 +653,26 @@ class _RunningEngine {
     });
 
     stdoutPort.listen((message) {
-      if (message is String) {
-        _logger.finest('[stdout] $message');
-        onStdout(message);
-      } else {
+      // A batch of lines from the reader, or a single line from a test's fake.
+      final lines = switch (message) {
+        final List<Object?> batch => batch,
+        final String line => [line],
+        _ => const <Object?>[],
+      };
+
+      if (lines.isEmpty) {
         _logger.fine('The stdout isolate sent $message');
+        return;
+      }
+
+      // Checked once rather than per line: this runs for every line the engine
+      // writes, and the interpolation below is not free when nobody is listening.
+      final trace = _logger.isLoggable(Level.FINEST);
+
+      for (final line in lines) {
+        if (line is! String) continue;
+        if (trace) _logger.finest('[stdout] $line');
+        onStdout(line);
       }
     });
   }
@@ -768,9 +783,12 @@ void _isolateStdout(_IsolateArgs args) {
     final data = previous + stdout;
     final lines = data.split('\n');
     previous = lines.removeLast();
-    for (final line in lines) {
-      stdoutPort.send(line);
-    }
+
+    // One message for the whole chunk rather than one per line. A page of
+    // engine output holds dozens of `info` lines during a multi-PV search, and
+    // every port message is an event the main isolate has to turn its loop for
+    // -- which is the isolate also running the UI and the start-up timeouts.
+    if (lines.isNotEmpty) stdoutPort.send(lines);
   }
 }
 

--- a/pkgs/multistockfish/lib/src/stockfish_state.dart
+++ b/pkgs/multistockfish/lib/src/stockfish_state.dart
@@ -1,6 +1,9 @@
 /// C++ engine state.
 enum StockfishState {
   /// Engine is not running.
+  ///
+  /// Only reachable through the deprecated `Stockfish.instance`, which can be
+  /// started again. An engine from `Stockfish.create` is already running.
   initial,
 
   /// Engine is starting.
@@ -9,6 +12,9 @@ enum StockfishState {
   /// Engine is running, ready to receive commands.
   ready,
 
-  /// An error occurred, engine could not start.
+  /// An error occurred: the engine could not start, or died on its own.
   error,
+
+  /// The engine has been disposed and its flavor's slot freed.
+  disposed,
 }

--- a/pkgs/multistockfish/test/bindings_test.dart
+++ b/pkgs/multistockfish/test/bindings_test.dart
@@ -1,0 +1,60 @@
+import 'dart:ffi' as ffi;
+
+import 'package:ffi/ffi.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:multistockfish/src/bindings.dart';
+
+/// Copies [bytes] into native memory, NUL-terminated, as the shim's buffer holds
+/// them.
+ffi.Pointer<ffi.Uint8> nativeBytes(List<int> bytes) {
+  final pointer = calloc<ffi.Uint8>(bytes.length + 1);
+  pointer.asTypedList(bytes.length + 1)
+    ..setAll(0, bytes)
+    ..[bytes.length] = 0;
+  return pointer;
+}
+
+void main() {
+  group('decodeEngineChunk', () {
+    test('decodes ordinary engine output', () {
+      final pointer = nativeBytes('info depth 20 score cp 31\n'.codeUnits);
+      addTearDown(() => calloc.free(pointer));
+
+      expect(decodeEngineChunk(pointer), 'info depth 20 score cp 31\n');
+    });
+
+    test('survives a multi-byte character split across two chunks', () {
+      // "é" is 0xC3 0xA9. A chunk boundary can fall between them, and the engine
+      // is only ever read a slice at a time — so this is a byte stream, not a
+      // string, and half a character is a legitimate thing to be handed.
+      final head = nativeBytes([...'info string caf'.codeUnits, 0xC3]);
+      final tail = nativeBytes([0xA9, ...'\n'.codeUnits]);
+      addTearDown(() => calloc.free(head));
+      addTearDown(() => calloc.free(tail));
+
+      // The point is that neither throws: an exception here would land in the
+      // reader isolate's loop and kill the only thing draining the engine's pipe.
+      expect(decodeEngineChunk(head), startsWith('info string caf'));
+      expect(decodeEngineChunk(tail), endsWith('\n'));
+    });
+
+    test('survives bytes that are not UTF-8 at all', () {
+      final pointer = nativeBytes([...'info '.codeUnits, 0xFF, 0xFE, 0x0A]);
+      addTearDown(() => calloc.free(pointer));
+
+      expect(decodeEngineChunk(pointer), startsWith('info '));
+    });
+
+    test('stops at the terminator, not at the end of the buffer', () {
+      // The shim hands back a 4096-byte buffer with the output NUL-terminated
+      // part way through it; everything past the NUL is the previous read's.
+      final pointer = calloc<ffi.Uint8>(64);
+      addTearDown(() => calloc.free(pointer));
+      final view = pointer.asTypedList(64)..fillRange(0, 64, 0x78);
+      view.setAll(0, 'uciok\n'.codeUnits);
+      view[6] = 0;
+
+      expect(decodeEngineChunk(pointer), 'uciok\n');
+    });
+  });
+}

--- a/pkgs/multistockfish/test/stockfish_test.dart
+++ b/pkgs/multistockfish/test/stockfish_test.dart
@@ -655,7 +655,11 @@ void main() {
           onTimeout: () => fail('dispose() hung on a dead engine'),
         );
 
-        expect(engine.state.value, StockfishState.disposed);
+        expect(
+          engine.state.value,
+          StockfishState.error,
+          reason: 'disposing a failed engine is not what went wrong',
+        );
         expect(Stockfish.debugLiveEngines, isEmpty);
       });
     });
@@ -811,26 +815,46 @@ void main() {
       final controller = MockEngineController();
 
       await runWithMockStockfish(controller, () async {
-        final future = Stockfish.create();
+        final engine = await createEngine(controller);
         final lines = <String>[];
-
-        // The engine exists as soon as create() has claimed the slot and
-        // spawned it, so a listener can be attached before it is ready.
-        controller.emitStdout('Stockfish 16');
-        await Future.delayed(Duration.zero);
-        expect(controller.bindings.stdinCalls.lastOrNull, 'uci\n');
-
-        final engine = Stockfish.debugLiveEngines[StockfishFlavor.sf16]!;
         engine.stdout.listen(lines.add);
 
-        controller.emitStdout('id name Stockfish');
-        controller.emitStdout('uciok');
-        await future;
+        controller.emitStdout('info depth 12');
+        controller.emitStdout('bestmove e2e4');
         await Future.delayed(Duration.zero);
 
-        expect(lines, containsAll(['id name Stockfish', 'uciok']));
+        expect(lines, ['info depth 12', 'bestmove e2e4']);
       });
     });
+
+    test(
+      'onStdout sees the startup output stdout has already missed',
+      () async {
+        final controller = MockEngineController();
+
+        await runWithMockStockfish(controller, () async {
+          final fromCreate = <String>[];
+          final future = Stockfish.create(onStdout: fromCreate.add);
+          await controller.simulateStartup();
+          final engine = await future;
+
+          // create() only completes once the engine is ready, so a listener
+          // attached to stdout here is already too late for the banner.
+          final fromStdout = <String>[];
+          engine.stdout.listen(fromStdout.add);
+          await Future.delayed(Duration.zero);
+
+          expect(fromCreate, ['Stockfish 16', 'uciok']);
+          expect(fromStdout, isEmpty);
+
+          // It keeps receiving for the engine's whole life, though.
+          controller.emitStdout('bestmove e2e4');
+          await Future.delayed(Duration.zero);
+          expect(fromCreate, contains('bestmove e2e4'));
+          expect(fromStdout, ['bestmove e2e4']);
+        });
+      },
+    );
   });
 
   group('Stockfish.state', () {
@@ -849,13 +873,38 @@ void main() {
         expect(states, [StockfishState.error]);
         expect(() => engine.stdin = 'isready', throwsStateError);
 
-        // The slot is the caller's to release, so a replacement is refused
-        // until the dead handle is disposed.
-        await expectLater(Stockfish.create(), throwsStateError);
-        await engine.dispose();
-
+        // The engine is gone, so its flavor is free: a replacement does not
+        // have to wait for the dead handle to be disposed.
+        expect(Stockfish.debugLiveEngines, isEmpty);
         final replacement = await createEngine(controller);
         expect(replacement.state.value, StockfishState.ready);
+      });
+    });
+
+    test('an engine sent `quit` ends as disposed, not as an error', () async {
+      final controller = MockEngineController();
+
+      await runWithMockStockfish(controller, () async {
+        final engine = await createEngine(controller);
+        final states = <StockfishState>[];
+        engine.state.addListener(() => states.add(engine.state.value));
+
+        // Quitting over stdin is a supported way to stop an engine, and the
+        // engine exits cleanly: nothing failed.
+        engine.stdin = 'quit';
+        controller.exit(0);
+        await Future.delayed(Duration.zero);
+
+        expect(engine.state.value, StockfishState.disposed);
+        expect(states, [StockfishState.disposed]);
+        expect(Stockfish.debugLiveEngines, isEmpty);
+
+        // Disposing afterwards is a no-op that completes.
+        await engine.dispose().timeout(
+          const Duration(seconds: 2),
+          onTimeout: () => fail('dispose() hung on an engine that had quit'),
+        );
+        expect(engine.state.value, StockfishState.disposed);
       });
     });
   });

--- a/pkgs/multistockfish/test/stockfish_test.dart
+++ b/pkgs/multistockfish/test/stockfish_test.dart
@@ -86,10 +86,29 @@ class MockEngine {
   /// Simulates the engine exiting with the given code.
   ///
   /// Exiting twice is a no-op, as it is for a real process.
+  ///
+  /// The reader stops too: a real engine writes the quit marker on its way out,
+  /// and the isolate reading its pipe returns as soon as it sees it. The handle
+  /// waits for both, so a mock that reported only the exit would leave every
+  /// teardown sitting on the reader timeout.
   void exit(int code) {
     if (_exited) return;
     _exited = true;
     _mainPort.send(code);
+    _stdoutPort.send(null);
+  }
+
+  /// Simulates an engine that exits without its reader ever letting go — one
+  /// wedged somewhere that never writes the quit marker.
+  void exitWithoutStoppingReader(int code) {
+    if (_exited) return;
+    _exited = true;
+    _mainPort.send(code);
+  }
+
+  /// Simulates the reader isolate seeing the quit marker and returning.
+  void stopReader() {
+    _stdoutPort.send(null);
   }
 }
 
@@ -692,6 +711,91 @@ void main() {
         zombie.exit(0);
         await Future.delayed(Duration.zero);
         expect(engine.state.value, StockfishState.disposed);
+      });
+    });
+
+    test(
+      'waits for the reader to let go of the pipe before it returns',
+      () async {
+        final controller = MockEngineController();
+
+        await runWithMockStockfish(controller, () async {
+          final engine = await createEngine(controller);
+
+          var disposed = false;
+          unawaited(engine.dispose().then((_) => disposed = true));
+          await pumpEventQueue();
+
+          // The engine is gone, but its reader is still blocked on the pipe: it
+          // only learns of the exit from the quit marker the engine wrote on its
+          // way out.
+          controller.engine.exitWithoutStoppingReader(0);
+          await pumpEventQueue();
+          expect(
+            disposed,
+            isFalse,
+            reason:
+                'returning here would let the next create() drain the pipe out '
+                'from under a reader that has not stopped',
+          );
+
+          // The reader wakes, sees the marker and returns.
+          controller.engine.stopReader();
+          await pumpEventQueue();
+          expect(disposed, isTrue);
+        });
+      },
+    );
+
+    test('does not wait forever for a reader that never stops', () async {
+      final controller = MockEngineController();
+
+      await runWithMockStockfish(controller, () async {
+        final engine = await createEngine(controller);
+
+        // Real time rather than fakeAsync: the exit below travels over a
+        // ReceivePort, which only the real event loop delivers.
+        final elapsed = Stopwatch()..start();
+        final disposal = engine.dispose();
+        await pumpEventQueue();
+        controller.engine.exitWithoutStoppingReader(0);
+
+        await disposal.timeout(
+          kReaderStopTimeout * 3,
+          onTimeout:
+              () =>
+                  fail('dispose() hung waiting for a reader that never stops'),
+        );
+        elapsed.stop();
+
+        expect(
+          elapsed.elapsed,
+          greaterThanOrEqualTo(
+            kReaderStopTimeout - const Duration(milliseconds: 100),
+          ),
+          reason: 'it should have given the reader its full window first',
+        );
+        expect(engine.state.value, StockfishState.disposed);
+        expect(Stockfish.debugLiveEngines, isEmpty);
+      });
+    });
+
+    test('does not wait for the reader of an engine that never exited', () async {
+      final controller = MockEngineController();
+
+      await runWithMockStockfish(controller, () async {
+        final engine = await createEngine(controller);
+
+        fakeAsync((async) {
+          var disposed = false;
+          engine.dispose().then((_) => disposed = true);
+
+          // The engine is wedged: it never exits, so it never writes the marker
+          // and its reader is never going to stop. Waiting for one would add
+          // kReaderStopTimeout to a teardown that has already given up.
+          async.elapse(kQuitTimeout + const Duration(milliseconds: 1));
+          expect(disposed, isTrue);
+        });
       });
     });
 

--- a/pkgs/multistockfish/test/stockfish_test.dart
+++ b/pkgs/multistockfish/test/stockfish_test.dart
@@ -1,3 +1,7 @@
+// The deprecated singleton is still part of this release, and its behaviour is
+// still covered below.
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'dart:async';
 import 'dart:isolate';
 
@@ -8,6 +12,9 @@ import 'package:multistockfish/multistockfish.dart';
 import 'package:multistockfish/src/bindings.dart';
 
 /// Mock implementation of [StockfishBindings] for testing.
+///
+/// One per flavor, as in production: each native library has its own pipes,
+/// its own diagnostics and its own idea of whether a write succeeded.
 class MockStockfishBindings implements StockfishBindings {
   final List<String> stdinCalls = [];
   int initReturnValue = 0;
@@ -58,7 +65,10 @@ class MockStockfishBindings implements StockfishBindings {
 /// Each engine keeps its own ports, mirroring production, so that a test can
 /// make an old engine talk after a new one has been spawned.
 class MockEngine {
-  MockEngine(this._mainPort, this._stdoutPort);
+  MockEngine(this.flavor, this._mainPort, this._stdoutPort);
+
+  /// The flavor this engine was spawned for.
+  final StockfishFlavor flavor;
 
   final SendPort _mainPort;
   final SendPort _stdoutPort;
@@ -85,19 +95,40 @@ class MockEngine {
 
 /// Controller for simulating engine behavior in tests.
 class MockEngineController {
-  final MockStockfishBindings bindings = MockStockfishBindings();
+  final Map<StockfishFlavor, MockStockfishBindings> _bindings = {};
 
   /// Every engine spawned so far, in spawn order.
   final List<MockEngine> engines = [];
 
+  /// The high-water mark of [liveEngines].
+  int maxLiveEngines = 0;
+
+  Duration? _exitOnQuitAfter;
+
+  /// The mocked native library of [flavor].
+  MockStockfishBindings bindingsFor(StockfishFlavor flavor) =>
+      _bindings.putIfAbsent(
+        flavor,
+        () =>
+            MockStockfishBindings()
+              ..onStdin = (input) => _onStdin(flavor, input),
+      );
+
+  /// The mocked native library of the default flavor.
+  MockStockfishBindings get bindings => bindingsFor(StockfishFlavor.sf16);
+
   /// The most recently spawned engine.
   MockEngine get engine => engines.last;
+
+  /// The most recently spawned engine of [flavor], alive or not.
+  MockEngine engineOf(StockfishFlavor flavor) =>
+      engines.lastWhere((e) => e.flavor == flavor);
 
   /// Engines spawned but not yet exited.
   int get liveEngines => engines.where((e) => e.isAlive).length;
 
-  /// The high-water mark of [liveEngines].
-  int maxLiveEngines = 0;
+  MockEngine? _liveEngineOf(StockfishFlavor flavor) =>
+      engines.where((e) => e.flavor == flavor && e.isAlive).lastOrNull;
 
   /// Makes engines exit shortly after they are sent the `quit` command.
   ///
@@ -105,32 +136,47 @@ class MockEngineController {
   /// asynchronous, like a real engine's, so that enabling this exercises the
   /// window during which the engine has been told to quit but is still alive.
   void exitOnQuit({Duration after = Duration.zero}) {
-    bindings.onStdin = (input) {
-      if (input.trim() != 'quit') return;
-      final engine = engines.lastWhere((e) => e.isAlive);
-      Future.delayed(after, () => engine.exit(0));
-    };
+    _exitOnQuitAfter = after;
   }
 
-  /// Simulates the engine starting up by writing its version to stdout
-  /// and responding to the "uci" command with "uciok".
-  Future<void> simulateStartup({String engineName = 'Stockfish 16'}) async {
-    emitStdout(engineName);
+  void _onStdin(StockfishFlavor flavor, String input) {
+    final after = _exitOnQuitAfter;
+    if (after == null || input.trim() != 'quit') return;
+    final engine = _liveEngineOf(flavor);
+    if (engine == null) return;
+    Future.delayed(after, () => engine.exit(0));
+  }
 
-    // Yield so that `Stockfish.instance.start()` writes the "uci" command to stdin
+  /// Simulates the [flavor] engine starting up by writing its version to
+  /// stdout and responding to the "uci" command with "uciok".
+  Future<void> simulateStartup({
+    StockfishFlavor flavor = StockfishFlavor.sf16,
+    String engineName = 'Stockfish 16',
+  }) async {
+    emitStdout(engineName, flavor: flavor);
+
+    // Yield so that the engine being started writes the "uci" command to stdin
     await Future.delayed(Duration.zero);
-    expect(bindings.stdinCalls.lastOrNull, 'uci\n');
-    emitStdout('uciok');
+    expect(bindingsFor(flavor).stdinCalls.lastOrNull, 'uci\n');
+    emitStdout('uciok', flavor: flavor);
   }
 
-  /// Simulates the latest engine outputting a line to stdout.
-  void emitStdout(String line) {
-    engines.lastOrNull?.emitStdout(line);
+  /// Simulates the latest live engine of [flavor] outputting a line.
+  void emitStdout(String line, {StockfishFlavor? flavor}) {
+    final engine = flavor == null ? engines.lastOrNull : _liveEngineOf(flavor);
+    engine?.emitStdout(line);
   }
 
   /// Simulates the latest engine exiting with the given code.
   void exit(int code) {
     engines.lastOrNull?.exit(code);
+  }
+
+  /// Simulates every engine still running exiting with the given code.
+  void exitAll(int code) {
+    for (final engine in engines.where((e) => e.isAlive).toList()) {
+      engine.exit(code);
+    }
   }
 
   /// The spawn isolates override function for zone injection.
@@ -139,11 +185,11 @@ class MockEngineController {
     SendPort stdoutPort,
     StockfishFlavor flavor,
   ) async {
-    if (bindings.initReturnValue != 0) {
+    if (bindingsFor(flavor).initReturnValue != 0) {
       return false;
     }
 
-    engines.add(MockEngine(mainPort, stdoutPort));
+    engines.add(MockEngine(flavor, mainPort, stdoutPort));
     if (liveEngines > maxLiveEngines) maxLiveEngines = liveEngines;
 
     return true;
@@ -163,228 +209,196 @@ Future<T> runWithMockStockfish<T>(
       try {
         return await body();
       } finally {
-        // Clean up by simulating engine exit to reset state
-        controller.exit(0);
+        // Nothing may leak into the next test: the per-flavor slots and the
+        // singleton are process-wide. Exiting the engines first keeps the
+        // cleanup from waiting out a quit timeout.
+        controller.exitAll(0);
         await Future.delayed(Duration.zero);
+        for (final engine in Stockfish.debugLiveEngines.values.toList()) {
+          if (identical(engine, Stockfish.instance)) {
+            await engine.quit();
+          } else {
+            await engine.dispose();
+          }
+        }
       }
     },
     zoneValues: {
-      stockfishBindingsFactoryKey:
-          (StockfishFlavor flavor) => controller.bindings,
+      stockfishBindingsFactoryKey: controller.bindingsFor,
       stockfishSpawnIsolatesKey: controller.spawnIsolates,
     },
   );
 }
 
-void main() {
-  group('Stockfish.instance', () {
-    test('is a singleton', () {
-      expect(Stockfish.instance, same(Stockfish.instance));
-    });
+/// Creates an engine of [flavor] and drives its startup.
+Future<Stockfish> createEngine(
+  MockEngineController controller, {
+  StockfishFlavor flavor = StockfishFlavor.sf16,
+  String? variant,
+  String engineName = 'Stockfish 16',
+}) async {
+  final future = Stockfish.create(flavor: flavor, variant: variant);
+  await controller.simulateStartup(flavor: flavor, engineName: engineName);
+  return future;
+}
 
-    test('starts in initial state', () async {
+void main() {
+  group('Stockfish.create', () {
+    test('returns an engine that is ready for commands', () async {
       final controller = MockEngineController();
 
       await runWithMockStockfish(controller, () async {
-        expect(Stockfish.instance.state.value, StockfishState.initial);
-        expect(Stockfish.instance.flavor, StockfishFlavor.sf16);
+        final engine = await createEngine(controller);
+
+        expect(engine.state.value, StockfishState.ready);
+        expect(engine.flavor, StockfishFlavor.sf16);
+
+        engine.stdin = 'isready';
+        expect(controller.bindings.stdinCalls, contains('isready\n'));
       });
     });
-  });
 
-  group('Stockfish.start', () {
-    test('transitions to ready state on successful start', () async {
+    test('refuses a second engine of the same flavor', () async {
+      final controller = MockEngineController()..exitOnQuit();
+
+      await runWithMockStockfish(controller, () async {
+        final engine = await createEngine(controller);
+
+        await expectLater(
+          Stockfish.create(flavor: StockfishFlavor.sf16),
+          throwsStateError,
+        );
+
+        // Only the first engine was ever spawned.
+        expect(controller.engines, hasLength(1));
+
+        // The slot is the engine's to give back.
+        await engine.dispose();
+        final replacement = await createEngine(controller);
+        expect(replacement.state.value, StockfishState.ready);
+        expect(controller.engines, hasLength(2));
+      });
+    });
+
+    test('refuses a second engine while the first is still starting', () async {
       final controller = MockEngineController();
 
       await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-        final startFuture = stockfish.start();
+        final first = Stockfish.create(flavor: StockfishFlavor.sf16);
 
-        // Yield to let async code run
-        await Future.delayed(Duration.zero);
-        expect(stockfish.state.value, StockfishState.starting);
+        await expectLater(
+          Stockfish.create(flavor: StockfishFlavor.sf16),
+          throwsStateError,
+          reason:
+              'the slot is claimed before the engine is spawned, so two '
+              'concurrent creates cannot both reach the native library',
+        );
 
         await controller.simulateStartup();
-
-        await startFuture;
-        expect(stockfish.state.value, StockfishState.ready);
+        expect((await first).state.value, StockfishState.ready);
       });
     });
 
-    test('throws StateError when already running', () async {
-      final controller = MockEngineController();
+    test('runs two flavors at once, each with its own I/O and state', () async {
+      final controller = MockEngineController()..exitOnQuit();
 
       await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-        final startFuture = stockfish.start();
+        final analysis = await createEngine(controller);
+        final opponent = await createEngine(
+          controller,
+          flavor: StockfishFlavor.variant,
+          variant: 'crazyhouse',
+          engineName: 'Fairy-Stockfish',
+        );
 
-        controller.simulateStartup();
+        expect(controller.liveEngines, 2);
+        expect(analysis.state.value, StockfishState.ready);
+        expect(opponent.state.value, StockfishState.ready);
+        expect(opponent.variant, 'crazyhouse');
 
-        await startFuture;
+        final analysisLines = <String>[];
+        final opponentLines = <String>[];
+        analysis.stdout.listen(analysisLines.add);
+        opponent.stdout.listen(opponentLines.add);
 
-        expect(stockfish.state.value, StockfishState.ready);
+        analysis.stdin = 'go depth 20';
+        opponent.stdin = 'go movetime 500';
 
-        // Try to start again - should throw
-        expect(() => stockfish.start(), throwsStateError);
-      });
-    });
-
-    test('returns same Future when start is already in progress', () async {
-      final controller = MockEngineController();
-
-      await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-
-        // Start the engine but don't await yet
-        final startFuture1 = stockfish.start();
-
-        // Yield to let async code run
+        controller.emitStdout(
+          'info depth 20 score cp 31',
+          flavor: StockfishFlavor.sf16,
+        );
+        controller.emitStdout('bestmove e2e4', flavor: StockfishFlavor.variant);
         await Future.delayed(Duration.zero);
-        expect(stockfish.state.value, StockfishState.starting);
 
-        final startFuture2 = stockfish.start();
+        // Neither engine's traffic appears on the other's channel.
+        expect(analysisLines, ['info depth 20 score cp 31']);
+        expect(opponentLines, ['bestmove e2e4']);
+        expect(
+          controller.bindingsFor(StockfishFlavor.sf16).stdinCalls,
+          contains('go depth 20\n'),
+        );
+        expect(
+          controller.bindingsFor(StockfishFlavor.sf16).stdinCalls,
+          isNot(contains('go movetime 500\n')),
+        );
+        expect(
+          controller.bindingsFor(StockfishFlavor.variant).stdinCalls,
+          contains('go movetime 500\n'),
+        );
 
-        expect(startFuture2, same(startFuture1));
+        // Disposing one leaves the other alone.
+        await analysis.dispose();
 
-        controller.simulateStartup();
-
-        // Both should complete successfully
-        await Future.wait([startFuture1, startFuture2]);
-        expect(stockfish.state.value, StockfishState.ready);
+        expect(analysis.state.value, StockfishState.disposed);
+        expect(opponent.state.value, StockfishState.ready);
+        opponent.stdin = 'stop';
+        expect(
+          controller.bindingsFor(StockfishFlavor.variant).stdinCalls,
+          contains('stop\n'),
+        );
       });
     });
 
-    test('concurrent start calls all receive error on failure', () async {
-      final controller = MockEngineController();
-
-      await runWithMockStockfish(controller, () {
-        fakeAsync((async) {
-          Object? error1;
-          Object? error2;
-
-          final stockfish = Stockfish.instance;
-
-          // Start the engine (first caller)
-          final startFuture1 = stockfish.start();
-          startFuture1.catchError((e) {
-            error1 = e;
-            return null;
-          });
-
-          // Flush microtasks to let start() begin
-          async.flushMicrotasks();
-
-          // Call start again while in progress (second caller)
-          final startFuture2 = stockfish.start();
-          startFuture2.catchError((e) {
-            error2 = e;
-            return null;
-          });
-
-          // Both should be the same future
-          expect(startFuture2, same(startFuture1));
-
-          // Don't emit stdout - simulate timeout, then let the engine be
-          // given up on
-          async.elapse(
-            kStartTimeout + kQuitTimeout + const Duration(seconds: 1),
-          );
-
-          // Both callers should receive the same error
-          expect(error1, isA<TimeoutException>());
-          expect(error2, isA<TimeoutException>());
-          expect(stockfish.state.value, StockfishState.error);
-
-          // Clean up
-          controller.exit(0);
-          async.flushMicrotasks();
-        });
-      });
-    });
-
-    test('can restart after quit', () async {
-      final controller = MockEngineController();
-
-      await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-
-        // First start
-        final startFuture1 = stockfish.start();
-        controller.simulateStartup();
-        await startFuture1;
-        expect(stockfish.state.value, StockfishState.ready);
-
-        // Quit
-        final quitFuture = stockfish.quit();
-        controller.exit(0);
-        await quitFuture;
-        expect(stockfish.state.value, StockfishState.initial);
-
-        // Restart
-        final startFuture2 = stockfish.start();
-        controller.simulateStartup();
-        await startFuture2;
-        expect(stockfish.state.value, StockfishState.ready);
-      });
-    });
-
-    test('throws and sets error state when init fails', () async {
+    test('throws and frees the slot when init fails', () async {
       final controller = MockEngineController();
       controller.bindings.initReturnValue = 1;
 
       await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
+        await expectLater(Stockfish.create(), throwsException);
+        expect(Stockfish.debugLiveEngines, isEmpty);
 
-        await expectLater(stockfish.start(), throwsException);
-        expect(stockfish.state.value, StockfishState.error);
-      });
-    });
-
-    test('can restart after error', () async {
-      final controller = MockEngineController();
-      controller.bindings.initReturnValue = 1;
-
-      await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-
-        // First start fails
-        await expectLater(stockfish.start(), throwsException);
-        expect(stockfish.state.value, StockfishState.error);
-
-        // Fix the error and restart
+        // The flavor is available again once the cause is fixed.
         controller.bindings.initReturnValue = 0;
-        final startFuture = stockfish.start();
-        controller.simulateStartup();
-        await startFuture;
-        expect(stockfish.state.value, StockfishState.ready);
+        final engine = await createEngine(controller);
+        expect(engine.state.value, StockfishState.ready);
       });
     });
 
-    test('throws TimeoutException when engine does not respond', () async {
+    test('throws TimeoutException when the engine does not respond', () async {
       final controller = MockEngineController();
 
       await runWithMockStockfish(controller, () {
         fakeAsync((async) {
           Object? caughtError;
 
-          Stockfish.instance.start().catchError((e) {
-            caughtError = e;
-            return null;
-          });
+          Stockfish.create().then<void>(
+            (_) {},
+            onError: (Object e) => caughtError = e,
+          );
 
-          // Flush microtasks to let start() begin
           async.flushMicrotasks();
-
-          // Advance time past the start timeout, then past the grace period
-          // the failed engine is given to exit
           async.elapse(
             kStartTimeout + kQuitTimeout + const Duration(seconds: 1),
           );
 
           expect(caughtError, isA<TimeoutException>());
-          expect(Stockfish.instance.state.value, StockfishState.error);
+          expect(
+            Stockfish.debugLiveEngines,
+            isEmpty,
+            reason: 'a failed create must not keep the flavor to itself',
+          );
 
-          // Clean up
           controller.exit(0);
           async.flushMicrotasks();
         });
@@ -398,78 +412,102 @@ void main() {
         fakeAsync((async) {
           Object? caughtError;
 
-          Stockfish.instance.start().catchError((e) {
-            caughtError = e;
-            return null;
-          });
+          Stockfish.create().then<void>(
+            (_) {},
+            onError: (Object e) => caughtError = e,
+          );
 
           async.flushMicrotasks();
           async.elapse(kStartTimeout + const Duration(seconds: 1));
 
-          // The engine has been told to quit, but start() does not report
+          // The engine has been told to quit, but create() does not report
           // failure while the engine may still be winding down: letting the
           // caller retry now would run two engines at once.
           expect(controller.bindings.stdinCalls, contains('quit\n'));
           expect(caughtError, isNull);
-          expect(Stockfish.instance.state.value, StockfishState.starting);
+          expect(Stockfish.debugLiveEngines, isNotEmpty);
 
           async.elapse(kQuitTimeout);
 
           expect(caughtError, isA<TimeoutException>());
-          expect(Stockfish.instance.state.value, StockfishState.error);
+          expect(Stockfish.debugLiveEngines, isEmpty);
         });
       });
     });
 
-    test(
-      'a failed start does not leave an engine behind for the next one',
-      () async {
-        final controller = MockEngineController()..exitOnQuit();
+    test('reports an engine that exits during startup, without waiting out '
+        'the timeout', () async {
+      final controller = MockEngineController();
 
-        await runWithMockStockfish(controller, () {
-          fakeAsync((async) {
-            for (var attempt = 0; attempt < 3; attempt++) {
-              Stockfish.instance.start().catchError((_) => null);
-              async.flushMicrotasks();
-              async.elapse(
-                kStartTimeout + kQuitTimeout + const Duration(seconds: 1),
-              );
-            }
+      await runWithMockStockfish(controller, () async {
+        final future = Stockfish.create();
 
-            expect(controller.engines, hasLength(3));
-            expect(controller.maxLiveEngines, 1);
-            expect(controller.liveEngines, 0);
-          });
+        // The native library refused to run a second engine while the last one
+        // is still wedged, so main() returns immediately.
+        await Future.delayed(Duration.zero);
+        controller.engine.exit(-1);
+
+        await expectLater(
+          future.timeout(
+            const Duration(seconds: 1),
+            onTimeout:
+                () => fail('create() waited for an engine that had exited'),
+          ),
+          throwsA(
+            isA<Exception>().having(
+              (e) => e.toString(),
+              'message',
+              allOf(contains('exited while starting'), contains('-1')),
+            ),
+          ),
+        );
+
+        expect(Stockfish.debugLiveEngines, isEmpty);
+      });
+    });
+
+    test('a failed start does not leave an engine behind for the next '
+        'one', () async {
+      final controller = MockEngineController()..exitOnQuit();
+
+      await runWithMockStockfish(controller, () {
+        fakeAsync((async) {
+          for (var attempt = 0; attempt < 3; attempt++) {
+            Stockfish.create().then<void>((_) {}, onError: (Object _) {});
+            async.flushMicrotasks();
+            async.elapse(
+              kStartTimeout + kQuitTimeout + const Duration(seconds: 1),
+            );
+          }
+
+          expect(controller.engines, hasLength(3));
+          expect(controller.maxLiveEngines, 1);
+          expect(controller.liveEngines, 0);
         });
-      },
-    );
+      });
+    });
 
     test('an engine abandoned after a failed start cannot disturb the next '
         'one', () async {
       final controller = MockEngineController();
 
       await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-
-        // A first start times out, and the engine never honours the quit
+        // A first create times out, and the engine never honours the quit
         // command, so it is eventually given up on.
         fakeAsync((async) {
-          stockfish.start().catchError((_) => null);
+          Stockfish.create().then<void>((_) {}, onError: (Object _) {});
           async.flushMicrotasks();
           async.elapse(
             kStartTimeout + kQuitTimeout + const Duration(seconds: 1),
           );
-          expect(stockfish.state.value, StockfishState.error);
         });
 
         final abandoned = controller.engines.single;
         expect(abandoned.isAlive, isTrue);
 
         // The next engine starts normally.
-        final startFuture = stockfish.start();
-        await controller.simulateStartup();
-        await startFuture;
-        expect(stockfish.state.value, StockfishState.ready);
+        final engine = await createEngine(controller);
+        expect(engine.state.value, StockfishState.ready);
 
         // The abandoned engine finally comes back to life. Nothing it says
         // may reach the engine that replaced it.
@@ -477,31 +515,8 @@ void main() {
         abandoned.exit(0);
         await Future.delayed(Duration.zero);
 
-        expect(stockfish.state.value, StockfishState.ready);
-        stockfish.stdin = 'isready';
-
-        final quitFuture = stockfish.quit();
-        controller.exit(0);
-        await quitFuture;
-        expect(stockfish.state.value, StockfishState.initial);
-      });
-    });
-
-    test('configures flavor correctly', () async {
-      final controller = MockEngineController();
-
-      await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-        final startFuture = stockfish.start(
-          flavor: StockfishFlavor.variant,
-          variant: 'atomic',
-        );
-
-        controller.simulateStartup();
-        await startFuture;
-
-        expect(stockfish.flavor, StockfishFlavor.variant);
-        expect(stockfish.variant, 'atomic');
+        expect(engine.state.value, StockfishState.ready);
+        engine.stdin = 'isready';
       });
     });
 
@@ -509,18 +524,15 @@ void main() {
       final controller = MockEngineController();
 
       await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-        final startFuture = stockfish.start(
+        await createEngine(
+          controller,
           flavor: StockfishFlavor.variant,
           variant: 'atomic',
+          engineName: 'Fairy-Stockfish',
         );
 
-        controller.simulateStartup(engineName: 'Fairy-Stockfish');
-
-        await startFuture;
-
         expect(
-          controller.bindings.stdinCalls,
+          controller.bindingsFor(StockfishFlavor.variant).stdinCalls,
           contains('setoption name UCI_Variant value atomic\n'),
         );
       });
@@ -530,281 +542,379 @@ void main() {
       final controller = MockEngineController();
 
       await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-        final startFuture = stockfish.start(
+        final future = Stockfish.create(
           flavor: StockfishFlavor.latestNoNNUE,
           bigNetPath: '/path/to/big.nnue',
           smallNetPath: '/path/to/small.nnue',
         );
+        await controller.simulateStartup(
+          flavor: StockfishFlavor.latestNoNNUE,
+          engineName: 'Stockfish 18',
+        );
+        final engine = await future;
 
-        controller.simulateStartup(engineName: 'Stockfish 17');
+        expect(engine.bigNetPath, '/path/to/big.nnue');
+        expect(engine.smallNetPath, '/path/to/small.nnue');
 
-        await startFuture;
-
+        final calls =
+            controller.bindingsFor(StockfishFlavor.latestNoNNUE).stdinCalls;
         expect(
-          controller.bindings.stdinCalls,
+          calls,
           contains('setoption name EvalFile value /path/to/big.nnue\n'),
         );
         expect(
-          controller.bindings.stdinCalls,
+          calls,
           contains('setoption name EvalFileSmall value /path/to/small.nnue\n'),
         );
       });
     });
   });
 
-  group('Stockfish.quit', () {
-    test('completes immediately when already in initial state', () async {
+  group('Stockfish.dispose', () {
+    test('quits the engine, waits for it and frees the flavor', () async {
       final controller = MockEngineController();
 
       await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-        expect(stockfish.state.value, StockfishState.initial);
+        final engine = await createEngine(controller);
+        final states = <StockfishState>[];
+        engine.state.addListener(() => states.add(engine.state.value));
 
-        // Should complete immediately
-        await stockfish.quit();
-        expect(stockfish.state.value, StockfishState.initial);
-      });
-    });
-
-    test('sends quit command when ready and returns to initial', () async {
-      final controller = MockEngineController();
-
-      await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-        final startFuture = stockfish.start();
-
-        controller.simulateStartup();
-        await startFuture;
-
-        final quitFuture = stockfish.quit();
-
-        // Simulate engine exiting
-        controller.exit(0);
-
-        await quitFuture;
-
+        final disposeFuture = engine.dispose();
         expect(controller.bindings.stdinCalls, contains('quit\n'));
-        expect(stockfish.state.value, StockfishState.initial);
-      });
-    });
-
-    test('waits for ready state before sending quit when starting', () async {
-      final controller = MockEngineController();
-
-      await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-        stockfish.start(); // Don't await
-
-        await Future.delayed(Duration.zero);
-        expect(stockfish.state.value, StockfishState.starting);
-
-        final quitFuture = stockfish.quit();
-
-        // quit not yet sent
-        expect(controller.bindings.stdinCalls, isNot(contains('quit\n')));
-
-        // Simulate engine becoming ready
-        controller.simulateStartup();
-        await Future.delayed(Duration.zero);
-
-        // Now quit should be sent
-        expect(controller.bindings.stdinCalls, contains('quit\n'));
-
-        // Simulate engine exiting
-        controller.exit(0);
-
-        await quitFuture;
-        expect(stockfish.state.value, StockfishState.initial);
-      });
-    });
-
-    test('returns same Future when quit is already in progress', () async {
-      final controller = MockEngineController();
-
-      await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-        final startFuture = stockfish.start();
-
-        controller.simulateStartup();
-        await startFuture;
-
-        // Call quit multiple times concurrently
-        final quitFuture1 = stockfish.quit();
-        final quitFuture2 = stockfish.quit();
-        final quitFuture3 = stockfish.quit();
-
-        // All should be the same future
-        expect(quitFuture2, same(quitFuture1));
-        expect(quitFuture3, same(quitFuture1));
-
-        // Only one quit command should be sent
         expect(
-          controller.bindings.stdinCalls.where((c) => c == 'quit\n').length,
-          equals(1),
+          Stockfish.debugLiveEngines,
+          isNotEmpty,
+          reason: 'the slot is held until the engine has actually exited',
         );
 
-        // Simulate engine exiting
         controller.exit(0);
+        await disposeFuture;
 
-        // All futures should complete
-        await Future.wait([quitFuture1, quitFuture2, quitFuture3]);
-        expect(stockfish.state.value, StockfishState.initial);
+        expect(engine.state.value, StockfishState.disposed);
+        expect(states, [StockfishState.disposed]);
+        expect(Stockfish.debugLiveEngines, isEmpty);
+      });
+    });
+
+    test('closes the stdout stream and refuses further commands', () async {
+      final controller = MockEngineController()..exitOnQuit();
+
+      await runWithMockStockfish(controller, () async {
+        final engine = await createEngine(controller);
+
+        var done = false;
+        engine.stdout.listen(null, onDone: () => done = true);
+
+        await engine.dispose();
+        await Future.delayed(Duration.zero);
+
+        expect(done, isTrue);
+        expect(() => engine.stdin = 'isready', throwsStateError);
+      });
+    });
+
+    test('concurrent calls share the first one', () async {
+      final controller = MockEngineController();
+
+      await runWithMockStockfish(controller, () async {
+        final engine = await createEngine(controller);
+
+        final dispose1 = engine.dispose();
+        final dispose2 = engine.dispose();
+        expect(dispose2, same(dispose1));
+
+        expect(
+          controller.bindings.stdinCalls.where((c) => c == 'quit\n').length,
+          1,
+        );
+
+        controller.exit(0);
+        await Future.wait([dispose1, dispose2]);
+
+        // Disposing a disposed engine is a no-op, not a second quit.
+        await engine.dispose();
+        expect(
+          controller.bindings.stdinCalls.where((c) => c == 'quit\n').length,
+          1,
+        );
+      });
+    });
+
+    test('completes on an engine that has already died', () async {
+      final controller = MockEngineController();
+
+      await runWithMockStockfish(controller, () async {
+        final engine = await createEngine(controller);
+
+        controller.exit(1);
+        await Future.delayed(Duration.zero);
+        expect(engine.state.value, StockfishState.error);
+
+        await engine.dispose().timeout(
+          const Duration(seconds: 2),
+          onTimeout: () => fail('dispose() hung on a dead engine'),
+        );
+
+        expect(engine.state.value, StockfishState.disposed);
+        expect(Stockfish.debugLiveEngines, isEmpty);
+      });
+    });
+
+    test('abandons an engine that will not exit, and frees the flavor '
+        'anyway', () async {
+      final controller = MockEngineController();
+
+      await runWithMockStockfish(controller, () async {
+        final engine = await createEngine(controller);
+
+        fakeAsync((async) {
+          var disposed = false;
+          engine.dispose().then((_) => disposed = true);
+
+          async.flushMicrotasks();
+          expect(disposed, isFalse);
+
+          async.elapse(kQuitTimeout + const Duration(seconds: 1));
+          expect(disposed, isTrue);
+        });
+
+        expect(engine.state.value, StockfishState.disposed);
+        expect(Stockfish.debugLiveEngines, isEmpty);
+
+        // The wedged engine keeps running, but nothing it sends is delivered.
+        final zombie = controller.engines.single;
+        expect(zombie.isAlive, isTrue);
+        zombie.emitStdout('too late');
+        zombie.exit(0);
+        await Future.delayed(Duration.zero);
+        expect(engine.state.value, StockfishState.disposed);
+      });
+    });
+
+    test('gives up instead of hanging when quit cannot be delivered', () async {
+      final controller = MockEngineController();
+
+      await runWithMockStockfish(controller, () async {
+        final engine = await createEngine(controller);
+
+        // The engine has stopped reading, so it will never see "quit" and will
+        // never report an exit.
+        controller.bindings.stdinWriteReturnValue = -3;
+
+        await engine.dispose().timeout(
+          const Duration(seconds: 2),
+          onTimeout:
+              () => fail('dispose() hung waiting for an unreachable engine'),
+        );
+
+        expect(engine.state.value, StockfishState.disposed);
+        expect(Stockfish.debugLiveEngines, isEmpty);
       });
     });
   });
 
   group('Stockfish.stdin', () {
-    test('throws StateError when not ready', () async {
+    test('writes to its own flavor bindings', () async {
       final controller = MockEngineController();
 
       await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
+        final engine = await createEngine(controller);
 
-        expect(() => stockfish.stdin = 'uci', throwsStateError);
-      });
-    });
-
-    test('writes to bindings when ready', () async {
-      final controller = MockEngineController();
-
-      await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-        final startFuture = stockfish.start();
-
-        controller.simulateStartup();
-        await startFuture;
-
-        stockfish.stdin = 'uci';
-        stockfish.stdin = 'isready';
+        engine.stdin = 'uci';
+        engine.stdin = 'isready';
 
         expect(controller.bindings.stdinCalls, contains('uci\n'));
         expect(controller.bindings.stdinCalls, contains('isready\n'));
       });
     });
-  });
 
-  group('Stockfish.stdout', () {
-    test('emits lines from engine', () async {
+    test('logs a failed write instead of throwing', () async {
+      final controller = MockEngineController();
+      final records = <LogRecord>[];
+
+      final previousLevel = Logger.root.level;
+      Logger.root.level = Level.ALL;
+      final subscription = Logger.root.onRecord.listen(records.add);
+      addTearDown(() {
+        subscription.cancel();
+        Logger.root.level = previousLevel;
+      });
+
+      await runWithMockStockfish(controller, () async {
+        final engine = await createEngine(controller);
+
+        // The input pipe stayed full: the engine has stopped reading.
+        controller.bindings.stdinWriteReturnValue = -3;
+        controller.bindings.phaseReturnValue = StockfishPhase.uciLoop.code;
+
+        // Must not throw — a broken engine should not turn every command site
+        // into a try/catch.
+        expect(() => engine.stdin = 'go movetime 1000', returnsNormally);
+
+        final severe = records.where((r) => r.level >= Level.SEVERE);
+        expect(severe, isNotEmpty);
+        expect(severe.last.message, contains('go movetime 1000'));
+        expect(severe.last.message, contains('stopped reading'));
+
+        // Nothing was written, so the command stream is still coherent and the
+        // engine stays usable.
+        expect(engine.state.value, StockfishState.ready);
+      });
+    });
+
+    test('a partial write fails the engine so later commands throw', () async {
       final controller = MockEngineController();
 
       await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-        final lines = <String>[];
-        stockfish.stdout.listen(lines.add);
+        final engine = await createEngine(controller);
 
-        final startFuture = stockfish.start();
+        // Half a command reached the pipe: everything sent afterwards would
+        // concatenate onto that fragment.
+        controller.bindings.stdinWriteReturnValue =
+            StockfishWriteResult.partial;
 
-        controller.emitStdout('Stockfish 16');
-        controller.emitStdout('id name Stockfish');
-        controller.emitStdout('uciok');
+        engine.stdin = 'go movetime 1000';
 
-        await startFuture;
-        await Future.delayed(Duration.zero);
-
+        expect(engine.state.value, StockfishState.error);
         expect(
-          lines,
-          containsAll(['Stockfish 16', 'id name Stockfish', 'uciok']),
+          () => engine.stdin = 'stop',
+          throwsStateError,
+          reason: 'the session is over; commands must not keep flowing',
         );
       });
     });
 
-    test('persists across restarts', () async {
+    test('a new engine is the recovery from a partial write', () async {
       final controller = MockEngineController();
 
       await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-        final lines = <String>[];
-        stockfish.stdout.listen(lines.add);
+        final engine = await createEngine(controller);
 
-        // First session
-        final startFuture1 = stockfish.start();
-        controller.simulateStartup(engineName: 'Session 1');
-        await startFuture1;
+        controller.bindings.stdinWriteReturnValue =
+            StockfishWriteResult.partial;
+        engine.stdin = 'go movetime 1000';
+        expect(engine.state.value, StockfishState.error);
 
-        final quitFuture = stockfish.quit();
+        controller.bindings.stdinWriteReturnValue = 0;
+        final disposeFuture = engine.dispose();
         controller.exit(0);
-        await quitFuture;
+        await disposeFuture;
 
-        // Second session - same listener should receive events
-        final startFuture2 = stockfish.start();
-        controller.simulateStartup(engineName: 'Session 2');
-        await startFuture2;
+        final replacement = await createEngine(controller);
+        expect(replacement.state.value, StockfishState.ready);
+      });
+    });
+  });
 
+  group('Stockfish.stdout', () {
+    test('emits lines from its engine', () async {
+      final controller = MockEngineController();
+
+      await runWithMockStockfish(controller, () async {
+        final future = Stockfish.create();
+        final lines = <String>[];
+
+        // The engine exists as soon as create() has claimed the slot and
+        // spawned it, so a listener can be attached before it is ready.
+        controller.emitStdout('Stockfish 16');
+        await Future.delayed(Duration.zero);
+        expect(controller.bindings.stdinCalls.lastOrNull, 'uci\n');
+
+        final engine = Stockfish.debugLiveEngines[StockfishFlavor.sf16]!;
+        engine.stdout.listen(lines.add);
+
+        controller.emitStdout('id name Stockfish');
+        controller.emitStdout('uciok');
+        await future;
         await Future.delayed(Duration.zero);
 
-        expect(lines, containsAll(['Session 1', 'Session 2']));
+        expect(lines, containsAll(['id name Stockfish', 'uciok']));
       });
     });
   });
 
   group('Stockfish.state', () {
-    test('notifies listeners on state changes', () async {
+    test('a crash is an error the handle does not recover from', () async {
       final controller = MockEngineController();
 
       await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
+        final engine = await createEngine(controller);
         final states = <StockfishState>[];
+        engine.state.addListener(() => states.add(engine.state.value));
 
-        stockfish.state.addListener(() {
-          states.add(stockfish.state.value);
-        });
+        controller.exit(1);
+        await Future.delayed(Duration.zero);
 
-        final startFuture = stockfish.start();
-        controller.simulateStartup();
-        await startFuture;
+        expect(engine.state.value, StockfishState.error);
+        expect(states, [StockfishState.error]);
+        expect(() => engine.stdin = 'isready', throwsStateError);
 
-        final quitFuture = stockfish.quit();
-        controller.exit(0);
-        await quitFuture;
+        // The slot is the caller's to release, so a replacement is refused
+        // until the dead handle is disposed.
+        await expectLater(Stockfish.create(), throwsStateError);
+        await engine.dispose();
 
-        expect(states, [
-          StockfishState.starting,
-          StockfishState.ready,
-          StockfishState.initial,
-        ]);
+        final replacement = await createEngine(controller);
+        expect(replacement.state.value, StockfishState.ready);
+      });
+    });
+  });
+
+  group('Stockfish.diagnostics', () {
+    test('reports what its flavor library publishes', () async {
+      final controller = MockEngineController();
+      controller.bindingsFor(StockfishFlavor.variant)
+        ..phaseReturnValue = StockfishPhase.engineBooting.code
+        ..phaseStepReturnValue = 'nnue'
+        ..phaseElapsedMsReturnValue = 7000
+        ..lastErrorReturnValue = 'init: discarded 3 stale byte(s)';
+
+      await runWithMockStockfish(controller, () async {
+        final engine = await createEngine(
+          controller,
+          flavor: StockfishFlavor.variant,
+          engineName: 'Fairy-Stockfish',
+        );
+
+        final diagnostics = engine.diagnostics;
+        expect(diagnostics.phase, StockfishPhase.engineBooting);
+        expect(diagnostics.step, 'nnue');
+        expect(diagnostics.elapsed, const Duration(seconds: 7));
+        expect(diagnostics.lastError, 'init: discarded 3 stale byte(s)');
+        expect(diagnostics.looksStuck, isTrue);
       });
     });
 
-    test(
-      'transitions to error state on engine crash and can restart',
-      () async {
-        final controller = MockEngineController();
+    test('says where a start stalled when it times out', () async {
+      final controller = MockEngineController();
+      controller.bindings
+        ..phaseReturnValue = StockfishPhase.engineBooting.code
+        ..phaseStepReturnValue = 'nnue'
+        ..phaseElapsedMsReturnValue = 6000;
 
-        await runWithMockStockfish(controller, () async {
-          final stockfish = Stockfish.instance;
-          final states = <StockfishState>[];
+      await runWithMockStockfish(controller, () {
+        fakeAsync((async) {
+          Object? caughtError;
 
-          stockfish.state.addListener(() {
-            states.add(stockfish.state.value);
-          });
+          Stockfish.create().then<void>(
+            (_) {},
+            onError: (Object e) => caughtError = e,
+          );
 
-          // Start the engine
-          final startFuture = stockfish.start();
-          controller.simulateStartup();
-          await startFuture;
-          expect(stockfish.state.value, StockfishState.ready);
+          async.flushMicrotasks();
+          async.elapse(
+            kStartTimeout + kQuitTimeout + const Duration(seconds: 1),
+          );
 
-          // Simulate engine crash (non-zero exit code)
-          controller.exit(1);
-          await Future.delayed(Duration.zero);
+          expect(caughtError, isA<TimeoutException>());
+          expect(caughtError.toString(), contains('phase=engineBooting'));
+          expect(caughtError.toString(), contains('step=nnue'));
 
-          expect(stockfish.state.value, StockfishState.error);
-          expect(states, [
-            StockfishState.starting,
-            StockfishState.ready,
-            StockfishState.error,
-          ]);
-
-          // Should be able to restart after crash
-          final restartFuture = stockfish.start();
-          controller.simulateStartup();
-          await restartFuture;
-
-          expect(stockfish.state.value, StockfishState.ready);
+          controller.exit(0);
+          async.flushMicrotasks();
         });
-      },
-    );
+      });
+    });
   });
 
   group('StockfishPhase', () {
@@ -898,50 +1008,106 @@ void main() {
     });
   });
 
-  group('Stockfish.diagnostics', () {
-    test('reports what the native library publishes', () async {
+  group('Stockfish.instance (deprecated)', () {
+    test('is a singleton that starts in the initial state', () async {
       final controller = MockEngineController();
-      controller.bindings
-        ..phaseReturnValue = StockfishPhase.engineBooting.code
-        ..phaseStepReturnValue = 'nnue'
-        ..phaseElapsedMsReturnValue = 7000
-        ..lastErrorReturnValue = 'init: discarded 3 stale byte(s)';
 
-      await runWithMockStockfish(controller, () {
-        final diagnostics = Stockfish.instance.diagnostics;
-
-        expect(diagnostics.phase, StockfishPhase.engineBooting);
-        expect(diagnostics.step, 'nnue');
-        expect(diagnostics.elapsed, const Duration(seconds: 7));
-        expect(diagnostics.lastError, 'init: discarded 3 stale byte(s)');
-        expect(diagnostics.looksStuck, isTrue);
+      await runWithMockStockfish(controller, () async {
+        expect(Stockfish.instance, same(Stockfish.instance));
+        expect(Stockfish.instance.state.value, StockfishState.initial);
+        expect(Stockfish.instance.flavor, StockfishFlavor.sf16);
       });
     });
 
-    test('says where a start stalled when it times out', () async {
+    test('cannot be disposed', () async {
       final controller = MockEngineController();
-      controller.bindings
-        ..phaseReturnValue = StockfishPhase.engineBooting.code
-        ..phaseStepReturnValue = 'nnue'
-        ..phaseElapsedMsReturnValue = 6000;
+
+      await runWithMockStockfish(controller, () async {
+        expect(() => Stockfish.instance.dispose(), throwsStateError);
+      });
+    });
+
+    test('transitions to ready state on successful start', () async {
+      final controller = MockEngineController();
+
+      await runWithMockStockfish(controller, () async {
+        final stockfish = Stockfish.instance;
+        final startFuture = stockfish.start();
+
+        // Yield to let async code run
+        await Future.delayed(Duration.zero);
+        expect(stockfish.state.value, StockfishState.starting);
+
+        await controller.simulateStartup();
+
+        await startFuture;
+        expect(stockfish.state.value, StockfishState.ready);
+      });
+    });
+
+    test('throws StateError when already running', () async {
+      final controller = MockEngineController();
+
+      await runWithMockStockfish(controller, () async {
+        final stockfish = Stockfish.instance;
+        final startFuture = stockfish.start();
+
+        controller.simulateStartup();
+        await startFuture;
+
+        expect(stockfish.state.value, StockfishState.ready);
+        expect(() => stockfish.start(), throwsStateError);
+      });
+    });
+
+    test('returns same Future when start is already in progress', () async {
+      final controller = MockEngineController();
+
+      await runWithMockStockfish(controller, () async {
+        final stockfish = Stockfish.instance;
+
+        final startFuture1 = stockfish.start();
+
+        await Future.delayed(Duration.zero);
+        expect(stockfish.state.value, StockfishState.starting);
+
+        final startFuture2 = stockfish.start();
+        expect(startFuture2, same(startFuture1));
+
+        controller.simulateStartup();
+
+        await Future.wait([startFuture1, startFuture2]);
+        expect(stockfish.state.value, StockfishState.ready);
+      });
+    });
+
+    test('concurrent start calls all receive error on failure', () async {
+      final controller = MockEngineController();
 
       await runWithMockStockfish(controller, () {
         fakeAsync((async) {
-          Object? caughtError;
+          Object? error1;
+          Object? error2;
 
-          Stockfish.instance.start().catchError((e) {
-            caughtError = e;
-            return null;
-          });
+          final stockfish = Stockfish.instance;
+
+          final startFuture1 = stockfish.start();
+          startFuture1.catchError((Object e) => error1 = e);
 
           async.flushMicrotasks();
+
+          final startFuture2 = stockfish.start();
+          startFuture2.catchError((Object e) => error2 = e);
+
+          expect(startFuture2, same(startFuture1));
+
           async.elapse(
             kStartTimeout + kQuitTimeout + const Duration(seconds: 1),
           );
 
-          expect(caughtError, isA<TimeoutException>());
-          expect(caughtError.toString(), contains('phase=engineBooting'));
-          expect(caughtError.toString(), contains('step=nnue'));
+          expect(error1, isA<TimeoutException>());
+          expect(error2, isA<TimeoutException>());
+          expect(stockfish.state.value, StockfishState.error);
 
           controller.exit(0);
           async.flushMicrotasks();
@@ -949,93 +1115,113 @@ void main() {
       });
     });
 
-    test('logs a failed stdin write instead of throwing', () async {
+    test('can restart after quit, keeping its stdout listeners', () async {
       final controller = MockEngineController();
-      final records = <LogRecord>[];
-
-      final previousLevel = Logger.root.level;
-      Logger.root.level = Level.ALL;
-      final subscription = Logger.root.onRecord.listen(records.add);
-      addTearDown(() {
-        subscription.cancel();
-        Logger.root.level = previousLevel;
-      });
 
       await runWithMockStockfish(controller, () async {
         final stockfish = Stockfish.instance;
-        final startFuture = stockfish.start();
-        await controller.simulateStartup();
-        await startFuture;
+        final lines = <String>[];
+        final subscription = stockfish.stdout.listen(lines.add);
+        addTearDown(subscription.cancel);
 
-        // The input pipe stayed full: the engine has stopped reading.
-        controller.bindings.stdinWriteReturnValue = -3;
-        controller.bindings.phaseReturnValue = StockfishPhase.uciLoop.code;
-
-        // Must not throw — a broken engine should not turn every command site
-        // into a try/catch.
-        expect(() => stockfish.stdin = 'go movetime 1000', returnsNormally);
-
-        final severe = records.where((r) => r.level >= Level.SEVERE);
-        expect(severe, isNotEmpty);
-        expect(severe.last.message, contains('go movetime 1000'));
-        expect(severe.last.message, contains('stopped reading'));
-
-        // Nothing was written, so the command stream is still coherent and the
-        // engine stays usable.
+        final startFuture1 = stockfish.start();
+        await controller.simulateStartup(engineName: 'Session 1');
+        await startFuture1;
         expect(stockfish.state.value, StockfishState.ready);
-      });
-    });
 
-    test('a partial write fails the engine so later commands throw', () async {
-      final controller = MockEngineController();
-
-      await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-        final startFuture = stockfish.start();
-        await controller.simulateStartup();
-        await startFuture;
-
-        // Half a command reached the pipe: everything sent afterwards would
-        // concatenate onto that fragment.
-        controller.bindings.stdinWriteReturnValue =
-            StockfishWriteResult.partial;
-
-        stockfish.stdin = 'go movetime 1000';
-
-        expect(stockfish.state.value, StockfishState.error);
-        expect(
-          () => stockfish.stdin = 'stop',
-          throwsStateError,
-          reason: 'the session is over; commands must not keep flowing',
-        );
-      });
-    });
-
-    test('can restart after a partial write kills the session', () async {
-      final controller = MockEngineController();
-
-      await runWithMockStockfish(controller, () async {
-        final stockfish = Stockfish.instance;
-        final startFuture = stockfish.start();
-        await controller.simulateStartup();
-        await startFuture;
-
-        controller.bindings.stdinWriteReturnValue =
-            StockfishWriteResult.partial;
-        stockfish.stdin = 'go movetime 1000';
-        expect(stockfish.state.value, StockfishState.error);
-
-        // A restart is the documented recovery, and start() accepts the error
-        // state.
-        controller.bindings.stdinWriteReturnValue = 0;
+        final quitFuture = stockfish.quit();
+        expect(controller.bindings.stdinCalls, contains('quit\n'));
         controller.exit(0);
-        await Future<void>.delayed(Duration.zero);
+        await quitFuture;
+        expect(stockfish.state.value, StockfishState.initial);
 
-        final restartFuture = stockfish.start();
-        await controller.simulateStartup();
-        await restartFuture;
-
+        final startFuture2 = stockfish.start();
+        await controller.simulateStartup(engineName: 'Session 2');
+        await startFuture2;
         expect(stockfish.state.value, StockfishState.ready);
+
+        await Future.delayed(Duration.zero);
+        expect(lines, containsAll(['Session 1', 'Session 2']));
+      });
+    });
+
+    test('can restart after an error', () async {
+      final controller = MockEngineController();
+      controller.bindings.initReturnValue = 1;
+
+      await runWithMockStockfish(controller, () async {
+        final stockfish = Stockfish.instance;
+
+        await expectLater(stockfish.start(), throwsException);
+        expect(stockfish.state.value, StockfishState.error);
+
+        controller.bindings.initReturnValue = 0;
+        final startFuture = stockfish.start();
+        await controller.simulateStartup();
+        await startFuture;
+        expect(stockfish.state.value, StockfishState.ready);
+      });
+    });
+
+    test('waits for ready state before sending quit when starting', () async {
+      final controller = MockEngineController();
+
+      await runWithMockStockfish(controller, () async {
+        final stockfish = Stockfish.instance;
+        stockfish.start(); // Don't await
+
+        await Future.delayed(Duration.zero);
+        expect(stockfish.state.value, StockfishState.starting);
+
+        final quitFuture = stockfish.quit();
+
+        // quit not yet sent
+        expect(controller.bindings.stdinCalls, isNot(contains('quit\n')));
+
+        await controller.simulateStartup();
+        await Future.delayed(Duration.zero);
+
+        expect(controller.bindings.stdinCalls, contains('quit\n'));
+
+        controller.exit(0);
+        await quitFuture;
+        expect(stockfish.state.value, StockfishState.initial);
+      });
+    });
+
+    test('returns same Future when quit is already in progress', () async {
+      final controller = MockEngineController();
+
+      await runWithMockStockfish(controller, () async {
+        final stockfish = Stockfish.instance;
+        final startFuture = stockfish.start();
+        await controller.simulateStartup();
+        await startFuture;
+
+        final quitFuture1 = stockfish.quit();
+        final quitFuture2 = stockfish.quit();
+        expect(quitFuture2, same(quitFuture1));
+
+        expect(
+          controller.bindings.stdinCalls.where((c) => c == 'quit\n').length,
+          1,
+        );
+
+        controller.exit(0);
+        await Future.wait([quitFuture1, quitFuture2]);
+        expect(stockfish.state.value, StockfishState.initial);
+      });
+    });
+
+    test('quit completes immediately when already in initial state', () async {
+      final controller = MockEngineController();
+
+      await runWithMockStockfish(controller, () async {
+        final stockfish = Stockfish.instance;
+        expect(stockfish.state.value, StockfishState.initial);
+
+        await stockfish.quit();
+        expect(stockfish.state.value, StockfishState.initial);
       });
     });
 
@@ -1064,5 +1250,68 @@ void main() {
         });
       },
     );
+
+    test(
+      'transitions to error state on engine crash and can restart',
+      () async {
+        final controller = MockEngineController();
+
+        await runWithMockStockfish(controller, () async {
+          final stockfish = Stockfish.instance;
+          final states = <StockfishState>[];
+          stockfish.state.addListener(() => states.add(stockfish.state.value));
+
+          final startFuture = stockfish.start();
+          await controller.simulateStartup();
+          await startFuture;
+          expect(stockfish.state.value, StockfishState.ready);
+
+          controller.exit(1);
+          await Future.delayed(Duration.zero);
+
+          expect(stockfish.state.value, StockfishState.error);
+          expect(states, [
+            StockfishState.starting,
+            StockfishState.ready,
+            StockfishState.error,
+          ]);
+
+          final restartFuture = stockfish.start();
+          await controller.simulateStartup();
+          await restartFuture;
+
+          expect(stockfish.state.value, StockfishState.ready);
+        });
+      },
+    );
+
+    test('competes for the same flavor slot as create()', () async {
+      final controller = MockEngineController()..exitOnQuit();
+
+      await runWithMockStockfish(controller, () async {
+        final engine = await createEngine(controller);
+
+        // The singleton cannot take a flavor a handle already holds...
+        expect(() => Stockfish.instance.start(), throwsStateError);
+
+        await engine.dispose();
+
+        final startFuture = Stockfish.instance.start();
+        await controller.simulateStartup();
+        await startFuture;
+
+        // ...and a handle cannot take one the singleton holds.
+        await expectLater(Stockfish.create(), throwsStateError);
+
+        // A different flavor is unaffected.
+        final variant = await createEngine(
+          controller,
+          flavor: StockfishFlavor.variant,
+          engineName: 'Fairy-Stockfish',
+        );
+        expect(variant.state.value, StockfishState.ready);
+        await variant.dispose();
+      });
+    });
   });
 }

--- a/pkgs/multistockfish/test/stockfish_test.dart
+++ b/pkgs/multistockfish/test/stockfish_test.dart
@@ -110,6 +110,12 @@ class MockEngine {
   void stopReader() {
     _stdoutPort.send(null);
   }
+
+  /// Simulates the reader isolate dying on an error instead of finishing.
+  void failReader(String error) {
+    _stdoutPort.send({'error': error, 'stackTrace': '<no stack>'});
+    _stdoutPort.send(null);
+  }
 }
 
 /// Controller for simulating engine behavior in tests.
@@ -711,6 +717,23 @@ void main() {
         zombie.exit(0);
         await Future.delayed(Duration.zero);
         expect(engine.state.value, StockfishState.disposed);
+      });
+    });
+
+    test('fails the engine when its reader dies', () async {
+      final controller = MockEngineController();
+
+      await runWithMockStockfish(controller, () async {
+        final engine = await createEngine(controller);
+        expect(engine.state.value, StockfishState.ready);
+
+        // Nothing is draining the engine's output any more. It goes on running until its
+        // pipe fills and then answers nothing, so the session is over whatever it does.
+        controller.engine.failReader('Bad state: the reader blew up');
+        await pumpEventQueue();
+
+        expect(engine.state.value, StockfishState.error);
+        expect(() => engine.stdin = 'isready', throwsStateError);
       });
     });
 

--- a/pkgs/multistockfish_chess/ios/multistockfish_chess/Sources/multistockfish_chess/stockfish_nnue.cpp
+++ b/pkgs/multistockfish_chess/ios/multistockfish_chess/Sources/multistockfish_chess/stockfish_nnue.cpp
@@ -47,11 +47,11 @@ static size_t carry_length = 0;
 static bool quit_seen = false;
 
 // None of the three is atomic, because stdout_read() has exactly one caller: the
-// reader the Dart side runs for the engine it started. That was already true of
-// `buffer` alone, but these carry state *between* calls, so a second concurrent
-// reader would now splice one read's tail onto another's and could be handed the
-// end-of-output signal meant for the first. init() resets them for the same
-// reason it drains the pipes: it is the one point where no reader can be running.
+// reader the Dart side runs for the engine it started. They carry state between
+// calls, so a second concurrent reader would splice one read's tail onto
+// another's and could be handed the end-of-output signal meant for the first.
+// init() resets them for the same reason it drains the pipes: it is the one
+// point where no reader can be running.
 
 // ---------------------------------------------------------------------------
 // Diagnostics

--- a/pkgs/multistockfish_chess/ios/multistockfish_chess/Sources/multistockfish_chess/stockfish_nnue.cpp
+++ b/pkgs/multistockfish_chess/ios/multistockfish_chess/Sources/multistockfish_chess/stockfish_nnue.cpp
@@ -33,7 +33,25 @@
 
 static const char *QUITOK = "quitok\n";
 static int pipes[NUM_PIPES][2] = {{-1, -1}, {-1, -1}};
-static char buffer[80];
+// A page at a time, matching the buffer the engine's output stream flushes from.
+static char buffer[4096];
+
+// An unfinished tail held back from the previous read, because it might turn out
+// to be the start of the quit marker.
+static char carry[8];
+static size_t carry_length = 0;
+
+// Whether the quit marker has been seen. The output that preceded it in the same
+// read is handed over first, so the reader gets the engine's last words before it
+// is told to stop.
+static bool quit_seen = false;
+
+// None of the three is atomic, because stdout_read() has exactly one caller: the
+// reader the Dart side runs for the engine it started. That was already true of
+// `buffer` alone, but these carry state *between* calls, so a second concurrent
+// reader would now splice one read's tail onto another's and could be handed the
+// end-of-output signal meant for the first. init() resets them for the same
+// reason it drains the pipes: it is the one point where no reader can be running.
 
 // ---------------------------------------------------------------------------
 // Diagnostics
@@ -210,6 +228,12 @@ int stockfish_init()
         steady_now_ms() - g_phase_since_ms.load(std::memory_order_relaxed));
     return SF_INIT_ALREADY_RUNNING;
   }
+
+  // A reader that was killed rather than allowed to finish leaves its carry and
+  // its end-of-output flag behind. Left set, the flag would tell the *next*
+  // engine's reader to stop before it had read a byte.
+  carry_length = 0;
+  quit_seen = false;
 
   if (g_pipes_ready.load(std::memory_order_acquire))
   {
@@ -395,6 +419,27 @@ ssize_t stockfish_stdin_write(char *data)
   return (ssize_t)written;
 }
 
+// The length of the longest suffix of [data] that is a proper prefix of QUITOK.
+//
+// The marker is the last thing an engine writes, but a read can return it glued
+// to the output before it, and -- if the pipe happened to be full -- split across
+// two reads. Holding such a tail back is safe: every line the engine writes ends
+// in '\n', which no prefix of the marker does, so an unfinished tail always has
+// more data coming after it.
+static size_t partial_quit_length(const char *data, size_t length)
+{
+  const size_t marker = strlen(QUITOK);
+  size_t candidate = (marker - 1 < length) ? marker - 1 : length;
+
+  for (; candidate > 0; candidate--)
+  {
+    if (memcmp(data + length - candidate, QUITOK, candidate) == 0)
+      return candidate;
+  }
+
+  return 0;
+}
+
 char *stockfish_stdout_read()
 {
   if (!g_pipes_ready.load(std::memory_order_acquire))
@@ -403,28 +448,72 @@ char *stockfish_stdout_read()
     return NULL;
   }
 
-  ssize_t count = read(PARENT_READ_FD, buffer, sizeof(buffer) - 1);
-
-  if (count < 0)
+  // The marker was found last time and everything before it has been delivered.
+  // The engine is gone; tell the reader to stop.
+  if (quit_seen)
   {
-    set_error("stdout_read: read failed: %s", strerror(errno));
+    quit_seen = false;
+    carry_length = 0;
     return NULL;
   }
 
-  // End of file. Returning the empty buffer here would spin the reader.
-  if (count == 0)
-  {
-    set_error("stdout_read: the output pipe reached end of file");
-    return NULL;
-  }
+  const size_t marker = strlen(QUITOK);
 
-  buffer[count] = 0;
-  if (strcmp(buffer, QUITOK) == 0)
+  for (;;)
   {
-    return NULL;
-  }
+    memcpy(buffer, carry, carry_length);
 
-  return buffer;
+    const ssize_t count = read(PARENT_READ_FD, buffer + carry_length, sizeof(buffer) - 1 - carry_length);
+
+    if (count < 0)
+    {
+      set_error("stdout_read: read failed: %s", strerror(errno));
+      carry_length = 0;
+      return NULL;
+    }
+
+    // End of file. Returning the empty buffer here would spin the reader.
+    if (count == 0)
+    {
+      set_error("stdout_read: the output pipe reached end of file");
+      carry_length = 0;
+      return NULL;
+    }
+
+    size_t total = carry_length + (size_t)count;
+    carry_length = 0;
+    buffer[total] = 0;
+
+    // The marker is written on its own once the engine's output has been
+    // flushed, so it is always last -- but this read may have picked up output
+    // written before it.
+    if (total >= marker && memcmp(buffer + total - marker, QUITOK, marker) == 0)
+    {
+      total -= marker;
+      buffer[total] = 0;
+      if (total == 0)
+        return NULL;
+
+      quit_seen = true;
+      return buffer;
+    }
+
+    const size_t partial = partial_quit_length(buffer, total);
+    if (partial > 0)
+    {
+      memcpy(carry, buffer + total - partial, partial);
+      carry_length = partial;
+      total -= partial;
+      buffer[total] = 0;
+    }
+
+    // The whole read was an unfinished tail. Wait for the rest of it rather than
+    // handing the reader an empty string.
+    if (total == 0)
+      continue;
+
+    return buffer;
+  }
 }
 
 int stockfish_phase()

--- a/pkgs/multistockfish_sf16/ios/multistockfish_sf16/Sources/multistockfish_sf16/stockfish16.cpp
+++ b/pkgs/multistockfish_sf16/ios/multistockfish_sf16/Sources/multistockfish_sf16/stockfish16.cpp
@@ -50,11 +50,11 @@ static size_t carry_length = 0;
 static bool quit_seen = false;
 
 // None of the three is atomic, because stdout_read() has exactly one caller: the
-// reader the Dart side runs for the engine it started. That was already true of
-// `buffer` alone, but these carry state *between* calls, so a second concurrent
-// reader would now splice one read's tail onto another's and could be handed the
-// end-of-output signal meant for the first. init() resets them for the same
-// reason it drains the pipes: it is the one point where no reader can be running.
+// reader the Dart side runs for the engine it started. They carry state between
+// calls, so a second concurrent reader would splice one read's tail onto
+// another's and could be handed the end-of-output signal meant for the first.
+// init() resets them for the same reason it drains the pipes: it is the one
+// point where no reader can be running.
 
 // ---------------------------------------------------------------------------
 // Diagnostics

--- a/pkgs/multistockfish_sf16/ios/multistockfish_sf16/Sources/multistockfish_sf16/stockfish16.cpp
+++ b/pkgs/multistockfish_sf16/ios/multistockfish_sf16/Sources/multistockfish_sf16/stockfish16.cpp
@@ -36,7 +36,25 @@
 
 static const char *QUITOK = "quitok\n";
 static int pipes[NUM_PIPES][2] = {{-1, -1}, {-1, -1}};
-static char buffer[80];
+// A page at a time, matching the buffer the engine's output stream flushes from.
+static char buffer[4096];
+
+// An unfinished tail held back from the previous read, because it might turn out
+// to be the start of the quit marker.
+static char carry[8];
+static size_t carry_length = 0;
+
+// Whether the quit marker has been seen. The output that preceded it in the same
+// read is handed over first, so the reader gets the engine's last words before it
+// is told to stop.
+static bool quit_seen = false;
+
+// None of the three is atomic, because stdout_read() has exactly one caller: the
+// reader the Dart side runs for the engine it started. That was already true of
+// `buffer` alone, but these carry state *between* calls, so a second concurrent
+// reader would now splice one read's tail onto another's and could be handed the
+// end-of-output signal meant for the first. init() resets them for the same
+// reason it drains the pipes: it is the one point where no reader can be running.
 
 // ---------------------------------------------------------------------------
 // Diagnostics
@@ -222,6 +240,12 @@ int stockfish_sf16_init()
         steady_now_ms() - g_phase_since_ms.load(std::memory_order_relaxed));
     return SF_INIT_ALREADY_RUNNING;
   }
+
+  // A reader that was killed rather than allowed to finish leaves its carry and
+  // its end-of-output flag behind. Left set, the flag would tell the *next*
+  // engine's reader to stop before it had read a byte.
+  carry_length = 0;
+  quit_seen = false;
 
   if (g_pipes_ready.load(std::memory_order_acquire))
   {
@@ -410,6 +434,27 @@ ssize_t stockfish_sf16_stdin_write(char *data)
   return (ssize_t)written;
 }
 
+// The length of the longest suffix of [data] that is a proper prefix of QUITOK.
+//
+// The marker is the last thing an engine writes, but a read can return it glued
+// to the output before it, and -- if the pipe happened to be full -- split across
+// two reads. Holding such a tail back is safe: every line the engine writes ends
+// in '\n', which no prefix of the marker does, so an unfinished tail always has
+// more data coming after it.
+static size_t partial_quit_length(const char *data, size_t length)
+{
+  const size_t marker = strlen(QUITOK);
+  size_t candidate = (marker - 1 < length) ? marker - 1 : length;
+
+  for (; candidate > 0; candidate--)
+  {
+    if (memcmp(data + length - candidate, QUITOK, candidate) == 0)
+      return candidate;
+  }
+
+  return 0;
+}
+
 char *stockfish_sf16_stdout_read()
 {
   if (!g_pipes_ready.load(std::memory_order_acquire))
@@ -418,28 +463,72 @@ char *stockfish_sf16_stdout_read()
     return NULL;
   }
 
-  ssize_t count = read(PARENT_READ_FD, buffer, sizeof(buffer) - 1);
-
-  if (count < 0)
+  // The marker was found last time and everything before it has been delivered.
+  // The engine is gone; tell the reader to stop.
+  if (quit_seen)
   {
-    set_error("stdout_read: read failed: %s", strerror(errno));
+    quit_seen = false;
+    carry_length = 0;
     return NULL;
   }
 
-  // End of file. Returning the empty buffer here would spin the reader.
-  if (count == 0)
-  {
-    set_error("stdout_read: the output pipe reached end of file");
-    return NULL;
-  }
+  const size_t marker = strlen(QUITOK);
 
-  buffer[count] = 0;
-  if (strcmp(buffer, QUITOK) == 0)
+  for (;;)
   {
-    return NULL;
-  }
+    memcpy(buffer, carry, carry_length);
 
-  return buffer;
+    const ssize_t count = read(PARENT_READ_FD, buffer + carry_length, sizeof(buffer) - 1 - carry_length);
+
+    if (count < 0)
+    {
+      set_error("stdout_read: read failed: %s", strerror(errno));
+      carry_length = 0;
+      return NULL;
+    }
+
+    // End of file. Returning the empty buffer here would spin the reader.
+    if (count == 0)
+    {
+      set_error("stdout_read: the output pipe reached end of file");
+      carry_length = 0;
+      return NULL;
+    }
+
+    size_t total = carry_length + (size_t)count;
+    carry_length = 0;
+    buffer[total] = 0;
+
+    // The marker is written on its own once the engine's output has been
+    // flushed, so it is always last -- but this read may have picked up output
+    // written before it.
+    if (total >= marker && memcmp(buffer + total - marker, QUITOK, marker) == 0)
+    {
+      total -= marker;
+      buffer[total] = 0;
+      if (total == 0)
+        return NULL;
+
+      quit_seen = true;
+      return buffer;
+    }
+
+    const size_t partial = partial_quit_length(buffer, total);
+    if (partial > 0)
+    {
+      memcpy(carry, buffer + total - partial, partial);
+      carry_length = partial;
+      total -= partial;
+      buffer[total] = 0;
+    }
+
+    // The whole read was an unfinished tail. Wait for the rest of it rather than
+    // handing the reader an empty string.
+    if (total == 0)
+      continue;
+
+    return buffer;
+  }
 }
 
 int stockfish_sf16_phase()

--- a/pkgs/multistockfish_variant/ios/multistockfish_variant/Sources/multistockfish_variant/stockfish_variant.cpp
+++ b/pkgs/multistockfish_variant/ios/multistockfish_variant/Sources/multistockfish_variant/stockfish_variant.cpp
@@ -39,7 +39,25 @@
 
 static const char *QUITOK = "quitok\n";
 static int pipes[NUM_PIPES][2] = {{-1, -1}, {-1, -1}};
-static char buffer[80];
+// A page at a time, matching the buffer the engine's output stream flushes from.
+static char buffer[4096];
+
+// An unfinished tail held back from the previous read, because it might turn out
+// to be the start of the quit marker.
+static char carry[8];
+static size_t carry_length = 0;
+
+// Whether the quit marker has been seen. The output that preceded it in the same
+// read is handed over first, so the reader gets the engine's last words before it
+// is told to stop.
+static bool quit_seen = false;
+
+// None of the three is atomic, because stdout_read() has exactly one caller: the
+// reader the Dart side runs for the engine it started. That was already true of
+// `buffer` alone, but these carry state *between* calls, so a second concurrent
+// reader would now splice one read's tail onto another's and could be handed the
+// end-of-output signal meant for the first. init() resets them for the same
+// reason it drains the pipes: it is the one point where no reader can be running.
 
 // ---------------------------------------------------------------------------
 // Diagnostics
@@ -235,6 +253,12 @@ int stockfish_variant_init()
     return SF_INIT_ALREADY_RUNNING;
   }
 
+  // A reader that was killed rather than allowed to finish leaves its carry and
+  // its end-of-output flag behind. Left set, the flag would tell the *next*
+  // engine's reader to stop before it had read a byte.
+  carry_length = 0;
+  quit_seen = false;
+
   if (g_pipes_ready.load(std::memory_order_acquire))
   {
     // Reuse the existing pipes rather than creating a second pair, which is
@@ -422,6 +446,27 @@ ssize_t stockfish_variant_stdin_write(char *data)
   return (ssize_t)written;
 }
 
+// The length of the longest suffix of [data] that is a proper prefix of QUITOK.
+//
+// The marker is the last thing an engine writes, but a read can return it glued
+// to the output before it, and -- if the pipe happened to be full -- split across
+// two reads. Holding such a tail back is safe: every line the engine writes ends
+// in '\n', which no prefix of the marker does, so an unfinished tail always has
+// more data coming after it.
+static size_t partial_quit_length(const char *data, size_t length)
+{
+  const size_t marker = strlen(QUITOK);
+  size_t candidate = (marker - 1 < length) ? marker - 1 : length;
+
+  for (; candidate > 0; candidate--)
+  {
+    if (memcmp(data + length - candidate, QUITOK, candidate) == 0)
+      return candidate;
+  }
+
+  return 0;
+}
+
 char *stockfish_variant_stdout_read()
 {
   if (!g_pipes_ready.load(std::memory_order_acquire))
@@ -430,28 +475,72 @@ char *stockfish_variant_stdout_read()
     return NULL;
   }
 
-  ssize_t count = read(PARENT_READ_FD, buffer, sizeof(buffer) - 1);
-
-  if (count < 0)
+  // The marker was found last time and everything before it has been delivered.
+  // The engine is gone; tell the reader to stop.
+  if (quit_seen)
   {
-    set_error("stdout_read: read failed: %s", strerror(errno));
+    quit_seen = false;
+    carry_length = 0;
     return NULL;
   }
 
-  // End of file. Returning the empty buffer here would spin the reader.
-  if (count == 0)
-  {
-    set_error("stdout_read: the output pipe reached end of file");
-    return NULL;
-  }
+  const size_t marker = strlen(QUITOK);
 
-  buffer[count] = 0;
-  if (strcmp(buffer, QUITOK) == 0)
+  for (;;)
   {
-    return NULL;
-  }
+    memcpy(buffer, carry, carry_length);
 
-  return buffer;
+    const ssize_t count = read(PARENT_READ_FD, buffer + carry_length, sizeof(buffer) - 1 - carry_length);
+
+    if (count < 0)
+    {
+      set_error("stdout_read: read failed: %s", strerror(errno));
+      carry_length = 0;
+      return NULL;
+    }
+
+    // End of file. Returning the empty buffer here would spin the reader.
+    if (count == 0)
+    {
+      set_error("stdout_read: the output pipe reached end of file");
+      carry_length = 0;
+      return NULL;
+    }
+
+    size_t total = carry_length + (size_t)count;
+    carry_length = 0;
+    buffer[total] = 0;
+
+    // The marker is written on its own once the engine's output has been
+    // flushed, so it is always last -- but this read may have picked up output
+    // written before it.
+    if (total >= marker && memcmp(buffer + total - marker, QUITOK, marker) == 0)
+    {
+      total -= marker;
+      buffer[total] = 0;
+      if (total == 0)
+        return NULL;
+
+      quit_seen = true;
+      return buffer;
+    }
+
+    const size_t partial = partial_quit_length(buffer, total);
+    if (partial > 0)
+    {
+      memcpy(carry, buffer + total - partial, partial);
+      carry_length = partial;
+      total -= partial;
+      buffer[total] = 0;
+    }
+
+    // The whole read was an unfinished tail. Wait for the rest of it rather than
+    // handing the reader an empty string.
+    if (total == 0)
+      continue;
+
+    return buffer;
+  }
 }
 
 int stockfish_variant_phase()

--- a/pkgs/multistockfish_variant/ios/multistockfish_variant/Sources/multistockfish_variant/stockfish_variant.cpp
+++ b/pkgs/multistockfish_variant/ios/multistockfish_variant/Sources/multistockfish_variant/stockfish_variant.cpp
@@ -53,11 +53,11 @@ static size_t carry_length = 0;
 static bool quit_seen = false;
 
 // None of the three is atomic, because stdout_read() has exactly one caller: the
-// reader the Dart side runs for the engine it started. That was already true of
-// `buffer` alone, but these carry state *between* calls, so a second concurrent
-// reader would now splice one read's tail onto another's and could be handed the
-// end-of-output signal meant for the first. init() resets them for the same
-// reason it drains the pipes: it is the one point where no reader can be running.
+// reader the Dart side runs for the engine it started. They carry state between
+// calls, so a second concurrent reader would splice one read's tail onto
+// another's and could be handed the end-of-output signal meant for the first.
+// init() resets them for the same reason it drains the pipes: it is the one
+// point where no reader can be running.
 
 // ---------------------------------------------------------------------------
 // Diagnostics

--- a/pkgs/multistockfish_variant/test/shim_test.cpp
+++ b/pkgs/multistockfish_variant/test/shim_test.cpp
@@ -217,12 +217,12 @@ int main()
 
   // --- the quit marker arrives glued to the output before it ---------------
   //
-  // The reader used to take 79 bytes at a time and compare the whole buffer
-  // against the marker, so a marker sharing a read with the output before it was
-  // never recognised: the reader looped forever on an engine that had exited,
-  // and went on stealing the pipe from the engine that replaced it. Reading a
-  // page at a time makes a shared read the common case rather than a rare one,
-  // so nothing reads this session until after the engine is gone.
+  // A page-sized read usually picks the marker up in the same call as the output
+  // written before it, so recognising it has to be a suffix match rather than a
+  // whole-buffer one. A reader that misses it loops forever on an engine that
+  // has exited, and then takes the pipe from the engine that replaces it.
+  // Nothing reads this session until after the engine is gone, which is what
+  // puts the output and the marker in one read.
   fprintf(stderr, "\n-- quit marker after buffered output --\n");
   check(stockfish_variant_init() == 0, "init succeeds for the buffered session");
   {

--- a/pkgs/multistockfish_variant/test/shim_test.cpp
+++ b/pkgs/multistockfish_variant/test/shim_test.cpp
@@ -215,6 +215,51 @@ int main()
   check(same_fd(fd_identity(STDOUT_FILENO), stdout_at_start),
         "the process keeps its own stdout");
 
+  // --- the quit marker arrives glued to the output before it ---------------
+  //
+  // The reader used to take 79 bytes at a time and compare the whole buffer
+  // against the marker, so a marker sharing a read with the output before it was
+  // never recognised: the reader looped forever on an engine that had exited,
+  // and went on stealing the pipe from the engine that replaced it. Reading a
+  // page at a time makes a shared read the common case rather than a rare one,
+  // so nothing reads this session until after the engine is gone.
+  fprintf(stderr, "\n-- quit marker after buffered output --\n");
+  check(stockfish_variant_init() == 0, "init succeeds for the buffered session");
+  {
+    int code = -99;
+    std::thread engine([&code] { code = stockfish_variant_main(); });
+
+    // No reader thread, so the phase is the only way to tell the engine is up.
+    for (int waited = 0;
+         waited < 15000 && stockfish_variant_phase() != SF_PHASE_UCI_LOOP;
+         waited += 10)
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    check(stockfish_variant_phase() == SF_PHASE_UCI_LOOP, "the engine reached its loop");
+
+    // The banner, the handshake and the marker all pile up in the pipe together.
+    check(send("uci\n") > 0, "uci accepted");
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    check(send("quit\n") > 0, "quit accepted");
+    engine.join();
+    check(code == 0, "engine exits with 0");
+
+    std::string collected;
+    while (true)
+    {
+      char *chunk = stockfish_variant_stdout_read();
+      if (chunk == nullptr)
+        break;
+      collected += chunk;
+    }
+
+    check(collected.find("Fairy-Stockfish") != std::string::npos,
+          "the banner buffered before the marker is still delivered");
+    check(collected.find("uciok") != std::string::npos,
+          "so is the handshake that shared the marker's read");
+    check(collected.find("quitok") == std::string::npos,
+          "and the marker itself is not delivered as output");
+  }
+
   // --- the input pipe fills instead of blocking forever --------------------
   fprintf(stderr, "\n-- non-blocking write --\n");
   std::string filler(1024, 'x');


### PR DESCRIPTION
Needs #13 

One instance per flavour with dispose().

Deprecate the singleton facade.